### PR TITLE
Rasterplot: Use numpy for concatenation of spiketrains

### DIFF
--- a/viziphant/rasterplot.py
+++ b/viziphant/rasterplot.py
@@ -398,8 +398,7 @@ def rasterplot(spiketrain_list,
         max_y = 0
         for value in colorkeyvalues:
             idx = np.where(attribute_array[:, colorkey] == value)[0]
-            histout = axhistx.hist(np.concatenate([strain for strain in
-                                      [spiketrain_list[i] for i in idx]]),
+            histout = axhistx.hist(np.concatenate([spiketrain_list[i] for i in idx]),
                                      pophistbins, histtype='step', linewidth=1,
                                      color=colormap[int(value)])
             max_y = np.max([max_y, np.max(histout[0])])
@@ -409,8 +408,7 @@ def rasterplot(spiketrain_list,
             sum_color = separatorargs[0]['color']
         else:
             sum_color = sns.color_palette()[0]
-
-        histout = axhistx.hist(np.concatenate([strain for strain in spiketrain_list]),
+        histout = axhistx.hist(np.concatenate(spiketrain_list),
                                pophistbins, histtype='step', linewidth=1,
                                color=sum_color)
         max_y = np.max(histout[0])

--- a/viziphant/rasterplot.py
+++ b/viziphant/rasterplot.py
@@ -398,9 +398,8 @@ def rasterplot(spiketrain_list,
         max_y = 0
         for value in colorkeyvalues:
             idx = np.where(attribute_array[:, colorkey] == value)[0]
-            histout = axhistx.hist([stime for strain in
-                                      [spiketrain_list[i] for i in idx]
-                                      for stime in strain],
+            histout = axhistx.hist(np.concatenate([strain for strain in
+                                      [spiketrain_list[i] for i in idx]]),
                                      pophistbins, histtype='step', linewidth=1,
                                      color=colormap[int(value)])
             max_y = np.max([max_y, np.max(histout[0])])
@@ -411,8 +410,7 @@ def rasterplot(spiketrain_list,
         else:
             sum_color = sns.color_palette()[0]
 
-        histout = axhistx.hist([stime for strain in spiketrain_list
-                                      for stime in strain],
+        histout = axhistx.hist(np.concatenate([strain for strain in spiketrain_list]),
                                pophistbins, histtype='step', linewidth=1,
                                color=sum_color)
         max_y = np.max(histout[0])


### PR DESCRIPTION
Using numpy for concatenation instead of a list comprehension improves performance of the histogram calculation in rasterplot. While a list comprehension copies every single timestamp into a list of timestamps, numpy will just create a view a wrapper around the spiketrains. This decreases memory usage and speeds up the whole process.