### PR TITLE
Add plotting functions for the Elephant User Workshop

### DIFF
--- a/viziphant/rasterplot.py
+++ b/viziphant/rasterplot.py
@@ -647,7 +647,7 @@ def eventplot(times, labels, event=None, event_label_key=None, num_histogram_bin
         axes[0][idx].eventplot(times[idx])
         axes[1][idx].hist(np.concatenate(times[idx]).magnitude,
                           bins=num_histogram_bins)
-        axes[1][idx].set_xlabel(f'Time [{str(times[idx][0].units).split(" ")[-1]}]')
+        axes[1][idx].set_xlabel('Time [{units}]'.format(units=str(times[idx][0].units).split(" ")[-1]))
         axes[0][idx].set_title(labels[idx])
 
     if event is not None:

--- a/viziphant/spike_train_correlation.py
+++ b/viziphant/spike_train_correlation.py
@@ -1,0 +1,58 @@
+"""
+Simple plotting function for spike train correlation measures
+"""
+
+import numpy as np
+import seaborn as sns
+import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1 import make_axes_locatable, axes_size
+
+
+def corrcoef(cc, vmin=-1, vmax=1, style='ticks', cmap='bwr',
+             cax_aspect=20, cax_pad_fraction=.5, figsize=(8, 8)):
+    """
+    This function plots the cross-correlation matrix returned by
+    elephant.spike_train_correlation.corrcoef and adds a colour bar.
+
+    :param cc
+        output of elephant.spike_train_correlation.corrcoef
+    :param vmin
+        minimum correlation for colour mapping. Default: -1
+    :param vmax
+        maximum correlation for colour mapping. Default: 1
+    :param style: str
+        seaborn style setting. Default: 'ticks'
+    :param cmap
+        colour map. Default: 'bwr'
+    :param cax_aspect
+        aspect ratio of the colour bar. Default: 20
+    :param cax_pad_fraction
+        padding between matrix plot and colour bar
+        relative to colour bar width. Default: .5
+    :param figsize
+        size of the figure. Default (8, 8)
+    :return: fig, ax, cax
+        * fig is the handle of the created figure
+        * ax is the handle of the correlation matrix plot
+        * cax is the handle of the colour bar
+    """
+
+    # Initialise plotting canvas
+    sns.set_style(style)
+
+    # Initialise figure and image axis
+    fig, ax = plt.subplots(1, 1, subplot_kw={'aspect': 'equal'},
+                           figsize=figsize)
+
+    im = ax.imshow(cc, vmin=vmin, vmax=vmax, cmap=cmap)
+
+    # Initialise colour bar axis
+    divider = make_axes_locatable(ax)
+    width = axes_size.AxesY(ax, aspect=1./cax_aspect)
+    pad = axes_size.Fraction(cax_pad_fraction, width)
+    cax = divider.append_axes("right", size=width, pad=pad)
+
+    plt.colorbar(im, cax=cax)
+
+    return fig, ax, cax
+

--- a/viziphant/statistics.py
+++ b/viziphant/statistics.py
@@ -1,0 +1,49 @@
+"""
+Simple plotting functions for statistical measures of spike trains
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+import quantities as pq
+
+
+def isi(isis, labels, binsize=2*pq.ms, cutoff=250*pq.ms):
+    """
+    This function creates a simple histogram plot to visualise an ISI distribution
+    computed with elephant.statistics.isi.
+
+    Multiple plots are created side by side for nested sublists in the isis and labels
+    arguments.
+
+    :param isis
+        output of elephant.statistics.isi or list of multiple outputs
+    :param labels
+        list of labels corresponding to the isi distributions
+    :param binsize
+        binsize for the histogram. Default: 2 ms
+    :param cutoff
+        largest ISI to consider. Default: 250 ms
+    """
+
+    if hasattr(isis, 'units'):
+        isis = [isis]
+    if isinstance(labels, str):
+        labels = [labels]
+
+    fig, axes = plt.subplots(1, len(labels), sharex=True, sharey=True,
+                             figsize=(8 * len(labels), 3))
+
+    # make sure the indexing in the loop below does not break down for len(labels) = 1
+    axes = np.atleast_1d(axes)
+
+    bins = np.arange(0, cutoff.rescale(isis[0].units).magnitude.item(),
+                     binsize.rescale(isis[0].units).magnitude.item())
+
+    for idx, label in enumerate(labels):
+        axes[idx].hist(isis[idx], bins=bins)
+        axes[idx].set_title(labels[idx])
+        axes[idx].set_xlabel(f'ISI Length [{str(isis[0].units).split(" ")[-1]}]')
+    axes[0].set_ylabel('ISI\nHistogram')
+
+    return fig, axes
+

--- a/viziphant/statistics.py
+++ b/viziphant/statistics.py
@@ -42,7 +42,7 @@ def isi(isis, labels, binsize=2*pq.ms, cutoff=250*pq.ms):
     for idx, label in enumerate(labels):
         axes[idx].hist(isis[idx], bins=bins)
         axes[idx].set_title(labels[idx])
-        axes[idx].set_xlabel(f'ISI Length [{str(isis[0].units).split(" ")[-1]}]')
+        axes[idx].set_xlabel('ISI Length [{units}]'.format(units=str(isis[0].units).split(" ")[-1]))
     axes[0].set_ylabel('ISI\nHistogram')
 
     return fig, axes


### PR DESCRIPTION
I added some simple plotting functions I need for my spike train analysis showcase at the workshop:
- a simple eventplot that is not restricted to spiketrains and does not include a secondary histogram along the y-axis
- a simple histogram plot to visualise ISI distributions
- a simple colour plot to visualise cross-correlation matrices

I've just bunched everything together here, would you prefer one PR per added function?

What's your opinion on the module structure? I've replicated the structure of elephant where possible, so that you can for example do
```
isis = elephant.statistics.isi(some_spiketrain)
fig, ax = viziphant.statistics.isi(isis)
```