### PR TITLE
added SPADE patterns statistics plots

### DIFF
--- a/viziphant/spade.py
+++ b/viziphant/spade.py
@@ -5,9 +5,10 @@ Simple plotting functions for statistical measures of spike trains
 from collections import defaultdict
 
 import matplotlib.pyplot as plt
+import neo
 import numpy as np
 import quantities as pq
-import neo
+
 from viziphant.rasterplot import plot_raster
 
 
@@ -73,46 +74,28 @@ def plot_patterns_statistics(patterns, winlen, bin_size, n_neurons):
     return fig, axes
 
 
-def _build_mask(spiketrains, pattern):
-    mask_patterns = []
-    for index, st in enumerate(spiketrains):
-        if index in pattern['neurons']:
-            patt_st = neo.SpikeTrain(pattern['times'],
-                                     t_start=st.t_start,
-                                     t_stop=st.t_stop)
-        else:
-            patt_st = neo.SpikeTrain([]*pq.ms,
-                                     t_start=st.t_start,
-                                     t_stop=st.t_stop)
-        mask_patterns.append(patt_st)
-    return mask_patterns
-
-
 def plot_pattern(spiketrains, pattern):
     """
     Simple plot showing a rasterplot along with one chosen pattern with its
     spikes represented in red
 
-    Parameters:
-    spiketrains: list
-        List of neo.SpikeTrain of the original data
+    Parameters
+    ----------
+    spiketrains : list of neo.SpikeTrain
+        List of `neo.SpikeTrain` that were used as the input.
     pattern : dictionary
-        One pattern output of elephant.spade to be plotted
+        A pattern from a list of found patterns returned by
+        :func:`elephant.spade.spade` function.
 
     Returns
     -------
     ax : matplotlib.axes.Axes
     """
     ax = plot_raster(spiketrains)
-    mask_patterns = _build_mask(spiketrains, pattern)
-    for st_index, st in enumerate(mask_patterns):
-        # Dot display
-        if st.__len__():
-            for patt_occurrence in st:
-                ax.plot(patt_occurrence.rescale(pq.s).magnitude,
-                        st_index,
-                        '.',
-                        color='red')
-    ax.set_ylabel('neurons')
+    pattern_times = pattern['times'].rescale(pq.s).magnitude
+    # for each neuron that participated in the pattern
+    for neuron in pattern['neurons']:
+        ax.plot(pattern_times, [neuron] * len(pattern_times), '.', color='red')
+    ax.set_ylabel('Neuron')
     return ax
 

--- a/viziphant/spade.py
+++ b/viziphant/spade.py
@@ -1,0 +1,71 @@
+"""
+Simple plotting functions for statistical measures of spike trains
+"""
+
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import numpy as np
+import quantities as pq
+
+
+def plot_patterns_statistics(patterns, winlen, bin_size, n_neurons):
+    """
+    This function creates a histogram plot to visualise patterns statistics
+    output of a SPADE analysis (:func:`elephant.spade.spade`).
+
+    Parameters
+    ----------
+    patterns : list
+        The output of elephant.spade
+    winlen : int
+        window length of the SPADE analysis
+    bin_size : pq.Quantity
+        The bin size of the SPADE analysis
+    n_neurons : int
+        Number of neurons in the data set being analyzed
+
+    Returns
+    -------
+    fig : matplotlib.figure.Figure
+    ax : matplotlib.axes.Axes
+    """
+    patterns_dict = defaultdict(list)
+    for pattern in patterns:
+        patterns_dict['neurons'].append(pattern['neurons'])
+        patterns_dict['occurrences'].append(len(pattern['times']))
+        patterns_dict['pattern_size'].append(len(pattern['neurons']))
+        patterns_dict['lags'].append(pattern['lags'])
+    if winlen == 1:
+        # case of only synchronous patterns
+        fig, axes = plt.subplots(3, 1, figsize=(10, 8))
+    else:
+        # case of patterns with delays
+        fig, axes = plt.subplots(4, 1, figsize=(10, 10))
+    plt.subplots_adjust(hspace=0.5)
+    axes[0].set_title('Patterns statistics')
+    axes[0].hist(patterns_dict['neurons'],
+                 bins=np.arange(0, n_neurons + 1))
+    axes[0].set_xlabel('Neuronal participation in patterns')
+    axes[0].set_ylabel('Count')
+    axes[1].hist(patterns_dict['occurrences'],
+                 bins=np.arange(1.5, np.max(
+                     patterns_dict['occurrences']) + 1, 1))
+    axes[1].set_xlabel('Pattern occurrences')
+    axes[1].set_ylabel('Count')
+    axes[2].hist(patterns_dict['pattern_size'],
+                 bins=np.arange(1.5, np.max(patterns_dict['pattern_size']), 1))
+    axes[2].set_xlabel('Pattern size')
+    axes[2].set_ylabel('Count')
+    if winlen != 1:
+        # adding panel with histogram of lags for delayed patterns
+        axes[3].hist(patterns_dict['lags'],
+                     bins=np.arange(-bin_size.magnitude / 2,
+                                    winlen * bin_size.magnitude +
+                                    bin_size.magnitude / 2,
+                                    bin_size.magnitude))
+        axes[3].set_xlabel('lags (ms)')
+        axes3_xmax = winlen * bin_size.magnitude - bin_size.magnitude / 2
+        axes[3].set_xlim([-bin_size.magnitude / 2, axes3_xmax])
+        axes[3].set_ylabel('Count')
+    return fig, axes

--- a/viziphant/spade.py
+++ b/viziphant/spade.py
@@ -39,6 +39,8 @@ def plot_patterns_statistics(patterns, winlen, bin_size, n_neurons):
         patterns_dict['occurrences'].append(len(pattern['times']))
         patterns_dict['pattern_size'].append(len(pattern['neurons']))
         patterns_dict['lags'].append(pattern['lags'])
+    patterns_dict['neurons'] = np.hstack(patterns_dict['neurons'])
+    patterns_dict['lags'] = np.hstack(patterns_dict['lags'])
     if winlen == 1:
         # case of only synchronous patterns
         fig, axes = plt.subplots(3, 1, figsize=(10, 8))
@@ -47,8 +49,7 @@ def plot_patterns_statistics(patterns, winlen, bin_size, n_neurons):
         fig, axes = plt.subplots(4, 1, figsize=(10, 10))
     plt.subplots_adjust(hspace=0.5)
     axes[0].set_title('Patterns statistics')
-    axes[0].hist(patterns_dict['neurons'],
-                 bins=np.arange(0, n_neurons + 1))
+    axes[0].hist(patterns_dict['neurons'], bins=n_neurons)
     axes[0].set_xlabel('Neuronal participation in patterns')
     axes[0].set_ylabel('Count')
     axes[1].hist(patterns_dict['occurrences'],

--- a/viziphant/statistics.py
+++ b/viziphant/statistics.py
@@ -42,7 +42,7 @@ def plot_isi(intervals, label, binsize=2*pq.ms, cutoff=250*pq.ms):
     return fig, ax
 
 
-def plot_patterns_statistics(patterns, winlen, binsize, n_neurons):
+def plot_patterns_statistics(patterns, winlen, bin_size, n_neurons):
     """
     This function creates a histogram plot to visualise patterns statistics
     output of a SPADE analysis.
@@ -53,7 +53,7 @@ def plot_patterns_statistics(patterns, winlen, binsize, n_neurons):
         The output of elephant.spade
     winlen : int
         window length of the SPADE analysis
-    binsize : pq.Quantity
+    bin_size : pq.Quantity
         The bin size of the SPADE analysis
     n_neurons : int
         Number of neurons in the data set being analyzed
@@ -101,12 +101,12 @@ def plot_patterns_statistics(patterns, winlen, binsize, n_neurons):
     if winlen != 1:
         # adding panel with histogram of lags for delayed patterns
         axes[3].hist(patterns_dict['lags'],
-                     bins=np.arange(-binsize.magnitude/2,
-                                    winlen*binsize.magnitude +
-                                    binsize.magnitude/2,
-                                    binsize.magnitude))
+                     bins=np.arange(-bin_size.magnitude/2,
+                                    winlen*bin_size.magnitude +
+                                    bin_size.magnitude/2,
+                                    bin_size.magnitude))
         axes[3].set_xlabel('lags (ms)')
-        axes[3].set_xlim([-binsize.magnitude/2,
-                          winlen*binsize.magnitude - binsize.magnitude/2])
+        axes[3].set_xlim([-bin_size.magnitude/2,
+                          winlen*bin_size.magnitude - bin_size.magnitude/2])
         axes[3].set_ylabel('Count')
     return fig, axes

--- a/viziphant/statistics.py
+++ b/viziphant/statistics.py
@@ -2,8 +2,6 @@
 Simple plotting functions for statistical measures of spike trains
 """
 
-from collections import defaultdict
-
 import matplotlib.pyplot as plt
 import numpy as np
 import quantities as pq
@@ -42,65 +40,3 @@ def plot_isi(intervals, label, binsize=2 * pq.ms, cutoff=250 * pq.ms):
     ax.set_ylabel('Count')
 
     return fig, ax
-
-
-def plot_patterns_statistics(patterns, winlen, bin_size, n_neurons):
-    """
-    This function creates a histogram plot to visualise patterns statistics
-    output of a SPADE analysis.
-
-    Parameters
-    ----------
-    patterns : list
-        The output of elephant.spade
-    winlen : int
-        window length of the SPADE analysis
-    bin_size : pq.Quantity
-        The bin size of the SPADE analysis
-    n_neurons : int
-        Number of neurons in the data set being analyzed
-
-    Returns
-    -------
-    fig : matplotlib.figure.Figure
-    ax : matplotlib.axes.Axes
-    """
-    patterns_dict = defaultdict(list)
-    for pattern in patterns:
-        patterns_dict['neurons'].append(pattern['neurons'])
-        patterns_dict['occurrences'].append(len(pattern['times']))
-        patterns_dict['pattern_size'].append(len(pattern['neurons']))
-        patterns_dict['lags'].append(pattern['lags'])
-    if winlen == 1:
-        # case of only synchronous patterns
-        fig, axes = plt.subplots(3, 1, figsize=(10, 8))
-    else:
-        # case of patterns with delays
-        fig, axes = plt.subplots(4, 1, figsize=(10, 10))
-    plt.subplots_adjust(hspace=0.5)
-    axes[0].set_title('Patterns statistics')
-    axes[0].hist(patterns_dict['neurons'],
-                 bins=np.arange(0, n_neurons + 1))
-    axes[0].set_xlabel('Neuronal participation in patterns')
-    axes[0].set_ylabel('Count')
-    axes[1].hist(patterns_dict['occurrences'],
-                 bins=np.arange(1.5, np.max(
-                     patterns_dict['occurrences']) + 1, 1))
-    axes[1].set_xlabel('Pattern occurrences')
-    axes[1].set_ylabel('Count')
-    axes[2].hist(patterns_dict['pattern_size'],
-                 bins=np.arange(1.5, np.max(patterns_dict['pattern_size']), 1))
-    axes[2].set_xlabel('Pattern size')
-    axes[2].set_ylabel('Count')
-    if winlen != 1:
-        # adding panel with histogram of lags for delayed patterns
-        axes[3].hist(patterns_dict['lags'],
-                     bins=np.arange(-bin_size.magnitude / 2,
-                                    winlen * bin_size.magnitude +
-                                    bin_size.magnitude / 2,
-                                    bin_size.magnitude))
-        axes[3].set_xlabel('lags (ms)')
-        axes3_xmax = winlen * bin_size.magnitude - bin_size.magnitude / 2
-        axes[3].set_xlim([-bin_size.magnitude / 2, axes3_xmax])
-        axes[3].set_ylabel('Count')
-    return fig, axes

--- a/viziphant/statistics.py
+++ b/viziphant/statistics.py
@@ -41,3 +41,72 @@ def plot_isi(intervals, label, binsize=2*pq.ms, cutoff=250*pq.ms):
 
     return fig, ax
 
+
+def plot_patterns_statistics(patterns, winlen, binsize, n_neurons):
+    """
+    This function creates a histogram plot to visualise patterns statistics
+    output of a SPADE analysis.
+
+    Parameters
+    ----------
+    patterns : list
+        The output of elephant.spade
+    winlen : int
+        window length of the SPADE analysis
+    binsize : pq.Quantity
+        The bin size of the SPADE analysis
+    n_neurons : int
+        Number of neurons in the data set being analyzed
+
+    Returns
+    -------
+    fig : matplotlib.figure.Figure
+    ax : matplotlib.axes.Axes
+    """
+    patterns_dict = {'neurons': np.array([]),
+                     'occurrences': np.array([]),
+                     'pattern_size': np.array([]),
+                     'lags': np.array([])}
+    for pattern in patterns:
+        patterns_dict['neurons'] = \
+            np.append(patterns_dict['neurons'], pattern['neurons'])
+        patterns_dict['occurrences'] = \
+            np.append(patterns_dict['occurrences'], len(pattern['times']))
+        patterns_dict['pattern_size'] = \
+            np.append(patterns_dict['pattern_size'], len(pattern['neurons']))
+        patterns_dict['lags'] = \
+            np.append(patterns_dict['lags'], pattern['lags'])
+    if winlen == 1:
+        # case of only synchronous patterns
+        fig, axes = plt.subplots(3, 1, figsize=(10, 8))
+    else:
+        # case of patterns with delays
+        fig, axes = plt.subplots(4, 1, figsize=(10, 10))
+    plt.subplots_adjust(hspace=0.5)
+    axes[0].set_title('Patterns statistics')
+    axes[0].hist(patterns_dict['neurons'],
+                 bins=np.arange(0, n_neurons + 1))
+    axes[0].set_xlabel('Neuronal participation in patterns')
+    axes[0].set_ylabel('Count')
+    axes[1].hist(patterns_dict['occurrences'],
+                 bins=np.arange(1.5,
+                                np.max(patterns_dict['occurrences']) + 1, 1))
+    axes[1].set_xlabel('Pattern occurrences')
+    axes[1].set_ylabel('Count')
+    axes[2].hist(patterns_dict['pattern_size'],
+                 bins=np.arange(1.5,
+                 np.max(patterns_dict['pattern_size']), 1))
+    axes[2].set_xlabel('Pattern size')
+    axes[2].set_ylabel('Count')
+    if winlen != 1:
+        # adding panel with histogram of lags for delayed patterns
+        axes[3].hist(patterns_dict['lags'],
+                     bins=np.arange(-binsize.magnitude/2,
+                                    winlen*binsize.magnitude +
+                                    binsize.magnitude/2,
+                                    binsize.magnitude))
+        axes[3].set_xlabel('lags (ms)')
+        axes[3].set_xlim([-binsize.magnitude/2,
+                          winlen*binsize.magnitude - binsize.magnitude/2])
+        axes[3].set_ylabel('Count')
+    return fig, axes

--- a/viziphant/statistics.py
+++ b/viziphant/statistics.py
@@ -2,12 +2,14 @@
 Simple plotting functions for statistical measures of spike trains
 """
 
-import numpy as np
+from collections import defaultdict
+
 import matplotlib.pyplot as plt
+import numpy as np
 import quantities as pq
 
 
-def plot_isi(intervals, label, binsize=2*pq.ms, cutoff=250*pq.ms):
+def plot_isi(intervals, label, binsize=2 * pq.ms, cutoff=250 * pq.ms):
     """
     This function creates a simple histogram plot to visualise an inter-spike
     interval (ISI) distribution computed with elephant.statistics.isi.
@@ -63,19 +65,12 @@ def plot_patterns_statistics(patterns, winlen, bin_size, n_neurons):
     fig : matplotlib.figure.Figure
     ax : matplotlib.axes.Axes
     """
-    patterns_dict = {'neurons': np.array([]),
-                     'occurrences': np.array([]),
-                     'pattern_size': np.array([]),
-                     'lags': np.array([])}
+    patterns_dict = defaultdict(list)
     for pattern in patterns:
-        patterns_dict['neurons'] = \
-            np.append(patterns_dict['neurons'], pattern['neurons'])
-        patterns_dict['occurrences'] = \
-            np.append(patterns_dict['occurrences'], len(pattern['times']))
-        patterns_dict['pattern_size'] = \
-            np.append(patterns_dict['pattern_size'], len(pattern['neurons']))
-        patterns_dict['lags'] = \
-            np.append(patterns_dict['lags'], pattern['lags'])
+        patterns_dict['neurons'].append(pattern['neurons'])
+        patterns_dict['occurrences'].append(len(pattern['times']))
+        patterns_dict['pattern_size'].append(len(pattern['neurons']))
+        patterns_dict['lags'].append(pattern['lags'])
     if winlen == 1:
         # case of only synchronous patterns
         fig, axes = plt.subplots(3, 1, figsize=(10, 8))
@@ -89,24 +84,23 @@ def plot_patterns_statistics(patterns, winlen, bin_size, n_neurons):
     axes[0].set_xlabel('Neuronal participation in patterns')
     axes[0].set_ylabel('Count')
     axes[1].hist(patterns_dict['occurrences'],
-                 bins=np.arange(1.5,
-                                np.max(patterns_dict['occurrences']) + 1, 1))
+                 bins=np.arange(1.5, np.max(
+                     patterns_dict['occurrences']) + 1, 1))
     axes[1].set_xlabel('Pattern occurrences')
     axes[1].set_ylabel('Count')
     axes[2].hist(patterns_dict['pattern_size'],
-                 bins=np.arange(1.5,
-                 np.max(patterns_dict['pattern_size']), 1))
+                 bins=np.arange(1.5, np.max(patterns_dict['pattern_size']), 1))
     axes[2].set_xlabel('Pattern size')
     axes[2].set_ylabel('Count')
     if winlen != 1:
         # adding panel with histogram of lags for delayed patterns
         axes[3].hist(patterns_dict['lags'],
-                     bins=np.arange(-bin_size.magnitude/2,
-                                    winlen*bin_size.magnitude +
-                                    bin_size.magnitude/2,
+                     bins=np.arange(-bin_size.magnitude / 2,
+                                    winlen * bin_size.magnitude +
+                                    bin_size.magnitude / 2,
                                     bin_size.magnitude))
         axes[3].set_xlabel('lags (ms)')
-        axes[3].set_xlim([-bin_size.magnitude/2,
-                          winlen*bin_size.magnitude - bin_size.magnitude/2])
+        axes3_xmax = winlen * bin_size.magnitude - bin_size.magnitude / 2
+        axes[3].set_xlim([-bin_size.magnitude / 2, axes3_xmax])
         axes[3].set_ylabel('Count')
     return fig, axes


### PR DESCRIPTION
Adding function plotting pattern statistics of SPADE output.
- First panel: histogram of single neuron participation to patterns
- Second panel: histogram of number of occurrences of all patterns detected
- Third panel: histogram of pattern sizes
- Fourth panel (only if winlen !=1): histogram of delays between spikes in patterns. The panel is not displayed if the SPADE analysis is done only for synchronous patterns (in that case the only lag would be 0ms)