### PR TITLE
added `plot_time_histogram` function

### DIFF
--- a/viziphant/statistics.py
+++ b/viziphant/statistics.py
@@ -10,7 +10,7 @@ import quantities as pq
 def plot_isi(intervals, label, binsize=2*pq.ms, cutoff=250*pq.ms):
     """
     This function creates a simple histogram plot to visualise an inter-spike
-    interval (ISI) distribution computed with elephant.statistics.isi.
+    interval (ISI) distribution computed with `elephant.statistics.isi`.
 
     Parameters
     ----------
@@ -41,3 +41,72 @@ def plot_isi(intervals, label, binsize=2*pq.ms, cutoff=250*pq.ms):
 
     return fig, ax
 
+
+def plot_time_histogram(histogram, time_unit=None, y_label=None, max_y=None,
+                        event_time=None, event_label=None, **kwargs):
+    """
+    This function plots a time histogram, such as the result of
+    `elephant.statistics.time_histogram`.
+
+    Parameters
+    ----------
+    histogram : neo.AnalogSignal
+        Object containing the histogram bins.
+    time_unit : pq.Quantity, optional
+        Desired unit for the plot time axis.
+        If None, the current unit of `histogram` is used.
+        Default: None
+    y_label : str, optional
+        Label for the Y axis.
+        Default: None
+    max_y : int or float, optional
+        Maximum value for the Y axis.
+        Default: None
+    event_time : pq.Quantity, optional
+        To draw a vertical line showing an event in the plot. The `event_time`
+        is provided with respect to the start of the histogram.
+        The histogram times will be centered at this time (i.e., the point at
+        `event_time` will be zero).
+        Default: None
+    event_label : str, optional
+        Label of the event.
+        If None, the label is not plotted.
+        If `event_time` is None, this parameter is ignored.
+        Default: None
+    """
+    fig, ax = plt.subplots(**kwargs)
+
+    # Rescale the time axis if requested
+    if time_unit is None:
+        width = histogram.sampling_period.rescale(
+            histogram.times.units).magnitude
+        times = histogram.times.magnitude
+        time_unit = histogram.times.units.dimensionality
+    else:
+        width = histogram.sampling_period.rescale(time_unit).magnitude
+        times = histogram.times.rescale(time_unit).magnitude
+        time_unit = time_unit.units.dimensionality
+
+    # Shift times according to the event, if provided
+    if event_time is not None:
+        times = np.subtract(times, event_time.rescale(time_unit).magnitude)
+
+    # Create the plot
+    ax.bar(times, histogram.squeeze().magnitude, align='edge', width=width)
+    ax.set_xlabel("Time ({})".format(time_unit))
+
+    # Define Y label and Y-axis limits
+    if max_y is not None:
+        ax.set_ylim([0, max_y])
+
+    if y_label is not None:
+        ax.set_ylabel(y_label)
+
+    # Add the event line and label, if provided
+    if event_time is not None:
+        ax.axvline(0, linewidth=1, linestyle='solid', color='black')
+        if event_label is not None:
+            ax.text(0, ax.get_ylim()[1], event_label, horizontalalignment='center',
+                    verticalalignment='bottom')
+
+    return fig, ax

--- a/viziphant/statistics.py
+++ b/viziphant/statistics.py
@@ -2,8 +2,8 @@
 Simple plotting functions for statistical measures of spike trains
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 import quantities as pq
 
 
@@ -98,7 +98,7 @@ def plot_time_histogram(histogram, time_unit=None, y_label=None, max_y=None,
 
     # Create the plot
     ax.bar(times, histogram.squeeze().magnitude, align='edge', width=width)
-    ax.set_xlabel("Time ({})".format(time_unit))
+    ax.set_xlabel(f"Time ({time_unit})")
 
     # Define Y label and Y-axis limits
     if max_y is not None:
@@ -111,7 +111,8 @@ def plot_time_histogram(histogram, time_unit=None, y_label=None, max_y=None,
     if event_time is not None:
         ax.axvline(0, linewidth=1, linestyle='solid', color='black')
         if event_label is not None:
-            ax.text(0, ax.get_ylim()[1], event_label, horizontalalignment='center',
+            ax.text(0, ax.get_ylim()[1], event_label,
+                    horizontalalignment='center',
                     verticalalignment='bottom')
 
     return fig, ax

--- a/viziphant/statistics.py
+++ b/viziphant/statistics.py
@@ -73,6 +73,11 @@ def plot_time_histogram(histogram, time_unit=None, y_label=None, max_y=None,
         If None, the label is not plotted.
         If `event_time` is None, this parameter is ignored.
         Default: None
+
+    Returns
+    -------
+    fig : matplotlib.figure.Figure
+    ax : matplotlib.axes.Axes
     """
     fig, ax = plt.subplots(**kwargs)
 


### PR DESCRIPTION
Added a function to visualize a time histogram, such as the result of `elephant.statistics.time_histogram`.

The input is a `neo.AnalogSignal` object.

Function parameters support the following features/functionality:
- time_unit: change the unit of the time axis;
- event_time / event_label: show (with or without a label) a single event along the time axis. The time at the event is set to zero (useful for visualizing PSTHs);
- y_label / max_y: define the Y-axis label and maximum value.