### PR TITLE
Fixed Unitary Event Analysis plot

### DIFF
--- a/viziphant/unitary_event_analysis.py
+++ b/viziphant/unitary_event_analysis.py
@@ -51,7 +51,7 @@ plot_params_default = {
     # the actual unit ids from the experimental recording
     'unit_real_ids': None,
     # line width
-    'lw': 0.5,
+    'lw': 2,
     # marker size for the UEs and coincidences
     'ms': 5,
     # figure title
@@ -239,7 +239,7 @@ def plot_ue(spiketrains, Js_dict, significance_level=0.05,
         for n in range(1, n_neurons):
             # subtract 0.5 to separate the raster plots;
             # otherwise, the line crosses the raster spikes
-            ax.axhline(n * n_trials - 0.5, lw=plot_params['lw'], color='k')
+            ax.axhline(n * n_trials - 0.5, lw=0.5, color='k')
         ymax = max(ax.get_ylim()[1], 2 * n_trials - 0.5)
         ax.set_ylim([-0.5, ymax])
         ax.set_yticks([n_trials - 0.5, 2 * n_trials - 0.5])

--- a/viziphant/unitary_event_analysis.py
+++ b/viziphant/unitary_event_analysis.py
@@ -247,6 +247,7 @@ def plot_ue(spiketrains, Js_dict, significance_level=0.05,
         ax.set_ylabel('Trial', fontsize=plot_params['fsize'])
 
     for i, ax in enumerate(axes):
+        ax.set_xlim([t_winpos[0], t_winpos[-1] + win_size])
         ax.text(-0.05, 1.1, string.ascii_uppercase[i],
                 transform=ax.transAxes, size=plot_params['fsize'] + 5,
                 weight='bold')

--- a/viziphant/unitary_event_analysis.py
+++ b/viziphant/unitary_event_analysis.py
@@ -101,7 +101,7 @@ def plot_ue(spiketrains, Js_dict, significance_level=0.05,
         User-defined plotting parameters used to update the default plotting
         parameter values. The valid keys:
 
-        'events' : list
+        'events' : dict
           Epochs to be marked on the time axis.
         'figsize' : tuple of int
           The dimensions for the figure size.

--- a/viziphant/unitary_event_analysis.py
+++ b/viziphant/unitary_event_analysis.py
@@ -31,7 +31,7 @@ FigureUE = namedtuple("FigureUE", ['axes_spike_events',
 
 plot_params_default = {
     # epochs to be marked on the time axis
-    'events': [],
+    'events': {},
     # figure size
     'figsize': (10, 12),
     # right margin
@@ -59,8 +59,8 @@ plot_params_default = {
 }
 
 
-def plot_ue(data, Js_dict, sig_level, binsize, winsize, winstep,
-            pattern_hash, plot_params_user):
+def plot_ue(spiketrains, Js_dict, significance_level=0.05,
+            **plot_params_user):
     """
     Plots the results of pairwise unitary event analysis as a column of six
     subplots, comprised of raster plot, peri-stimulus time histogram,
@@ -69,91 +69,63 @@ def plot_ue(data, Js_dict, sig_level, binsize, winsize, winstep,
 
     Parameters
     ----------
-    data : list of list of neo.SpikeTrain
+    spiketrains : list of list of neo.SpikeTrain
         A nested list of trials, neurons and their neo.SpikeTrain objects,
         respectively. This should be identical to the one used to generate
         Js_dict.
     Js_dict : dict
-        The output of elephant.unitary_event_analysis.jointJ_window_analysis
+        The output of
+        :func:`elephant.unitary_event_analysis.jointJ_window_analysis`
         function. The values of each key has the shape of:
 
-        * different pattern hash --> 0-axis;
-        * different window --> 1-axis.
+          * different pattern hash --> 0-axis;
+          * different window --> 1-axis.
 
         Dictionary keys:
 
-        * 'Js': list of float
-
+        'Js': list of float
           JointSurprise of different given patterns within each window.
-        * 'indices': list of list of int
-
+        'indices': list of list of int
           A list of indices of pattern within each window.
-        * 'n_emp': list of int
-
+        'n_emp': list of int
           The empirical number of each observed pattern.
-        * 'n_exp': list of float
-
+        'n_exp': list of float
           The expected number of each pattern.
-        * 'rate_avg': list of float
-
+        'rate_avg': list of float
           The average firing rate of each neuron.
-    sig_level : float
+
+    significance_level : float
         The significance threshold used to determine which coincident events
         are classified as unitary events within a window.
-    binsize : quantities.Quantity
-        The size of bins for discretizing spike trains. This value should be
-        identical to the one used to generate Js_dict.
-    winsize : quantities.Quantity
-        The size of the window of analysis. This value should be identical to
-        the one used to generate Js_dict.
-    winstep : quantities.Quantity
-        The size of the window step. This value should be identical to the one
-        used to generate Js_dict.
-    pattern_hash : list of int
-        List of interested patterns in hash values. This value should be
-        identical to the one used to generate Js_dict.
-    plot_params_user : dict
-        A dictionary of plotting parameters used to update the default plotting
-        parameter values. Dictionary keys:
+    **plot_params_user
+        User-defined plotting parameters used to update the default plotting
+        parameter values. The valid keys:
 
-        * 'events' : list
-
+        'events' : list
           Epochs to be marked on the time axis.
-        * 'figsize' : tuple of int
-
+        'figsize' : tuple of int
           The dimensions for the figure size.
-        * 'right' : float
-
+        'right' : float
           The size of the right margin.
-        * 'top' : float
-
+        'top' : float
           The size of the top margin.
-        * 'bottom' : float
-
+        'bottom' : float
           The size of the bottom margin.
-        * 'left' : float
-
+        'left' : float
           The size of the left margin.
-        * 'hspace' : flaot
-
+        'hspace' : flaot
           The size of the horizontal white space between subplots.
-        * 'wspace' : float
-
+        'wspace' : float
           The width of the white space between subplots.
-        * 'fsize' : int
-
+        'fsize' : int
           The size of the font.
-        * 'unit_real_ids' : list of int
-
+        'unit_real_ids' : list of int
           The unit ids from the experimental recording.
-        * 'lw' : int
-
+        'lw' : int
           The default line width.
-        * 'S_ylim' : tuple of ints or floats
-
+        'S_ylim' : tuple of ints or floats
           The y-axis limits for the joint surprise plot.
-        * 'ms' : int
-
+        'ms' : int
           The marker size for the unitary events and coincidences.
 
     Returns
@@ -180,21 +152,30 @@ def plot_ue(data, Js_dict, sig_level, binsize, winsize, winstep,
         * axes_unitary_events : matplotlib.axes.Axes
 
           Contains the elements of the unitary events subplot.
+
+    Examples
+    --------
+    Refer to https://elephant.readthedocs.io/en/latest/tutorials/
+    unitary_event_analysis.html.
     """
 
-    t_start = data[0][0].t_start
-    t_stop = data[0][0].t_stop
+    t_start = spiketrains[0][0].t_start
+    t_stop = spiketrains[0][0].t_stop
 
-    N = len(data[0])
+    n_neurons = len(spiketrains[0])
 
-    t_winpos = ue._winpos(t_start, t_stop, winsize, winstep)
-    Js_sig = ue.jointJ(sig_level)
-    num_tr = len(data)
+    bin_size = Js_dict['input_parameters']['bin_size']
+    win_size = Js_dict['input_parameters']['win_size']
+    win_step = Js_dict['input_parameters']['win_step']
+
+    t_winpos = ue._winpos(t_start, t_stop, win_size, win_step)
+    Js_sig = ue.jointJ(significance_level)
+    n_trials = len(spiketrains)
 
     # figure format
     plot_params = plot_params_default.copy()
     plot_params.update(plot_params_user)
-    if len(plot_params['unit_real_ids']) != N:
+    if len(plot_params['unit_real_ids']) != n_neurons:
         raise ValueError('length of unit_ids should be' +
                          'equal to number of neurons!')
     plt.rcParams.update({'font.size': plot_params['fsize']})
@@ -217,18 +198,18 @@ def plot_ue(data, Js_dict, sig_level, binsize, winsize, winstep,
     print('plotting raster plot ...')
     ax0 = plt.subplot(num_row, 1, 1)
     ax0.set_title('Spike Events')
-    for n in range(N):
-        for tr, data_tr in enumerate(data):
+    for n in range(n_neurons):
+        for tr, data_tr in enumerate(spiketrains):
             ax0.plot(data_tr[n].rescale('ms').magnitude,
                      np.ones_like(data_tr[n].magnitude) *
-                     tr + n * (num_tr + 1) + 1,
+                     tr + n * (n_trials + 1) + 1,
                      '.', markersize=0.5, color='k')
-        if n < N - 1:
+        if n < n_neurons - 1:
             ax0.axhline((tr + 2) * (n + 1), lw=plot_params['lw'], color='k')
     ax0.set_ylim(0, (tr + 2) * (n + 1) + 1)
-    ax0.set_yticks([num_tr + 1, 2*num_tr + 1])
-    ax0.set_yticklabels([1, num_tr], fontsize=plot_params['fsize'])
-    ax0.set_xlim(0, (max(t_winpos) + winsize).rescale('ms').magnitude)
+    ax0.set_yticks([n_trials + 1, 2*n_trials + 1])
+    ax0.set_yticklabels([1, n_trials], fontsize=plot_params['fsize'])
+    ax0.set_xlim(0, (max(t_winpos) + win_size).rescale('ms').magnitude)
     ax0.set_ylabel('Trial', fontsize=plot_params['fsize'])
     for key in plot_params['events'].keys():
         for e_val in plot_params['events'][key]:
@@ -249,13 +230,13 @@ def plot_ue(data, Js_dict, sig_level, binsize, winsize, winstep,
     print('plotting Spike Rates ...')
     ax1 = plt.subplot(num_row, 1, 2, sharex=ax0)
     ax1.set_title('Spike Rates')
-    for n in range(N):
-        ax1.plot(t_winpos + winsize / 2.,
+    for n in range(n_neurons):
+        ax1.plot(t_winpos + win_size / 2.,
                  Js_dict['rate_avg'][:, n].rescale('Hz'),
                  label='Unit ' + str(plot_params['unit_real_ids'][n]),
                  lw=plot_params['lw'])
     ax1.set_ylabel('(1/s)', fontsize=plot_params['fsize'])
-    ax1.set_xlim(0, (max(t_winpos) + winsize).rescale('ms').magnitude)
+    ax1.set_xlim(0, (max(t_winpos) + win_size).rescale('ms').magnitude)
     ax1.legend(fontsize=plot_params['fsize']//2)
     for key in plot_params['events'].keys():
         for e_val in plot_params['events'][key]:
@@ -265,26 +246,26 @@ def plot_ue(data, Js_dict, sig_level, binsize, winsize, winstep,
     print('plotting Raw Coincidences ...')
     ax2 = plt.subplot(num_row, 1, 3, sharex=ax0)
     ax2.set_title('Coincident Events')
-    for n in range(N):
-        for tr, data_tr in enumerate(data):
+    for n in range(n_neurons):
+        for tr, data_tr in enumerate(spiketrains):
             ax2.plot(data_tr[n].rescale('ms').magnitude,
                      np.ones_like(data_tr[n].magnitude) *
-                     tr + n * (num_tr + 1) + 1,
+                     tr + n * (n_trials + 1) + 1,
                      '.', markersize=0.5, color='k')
             ax2.plot(
                 np.unique(Js_dict['indices']['trial' + str(tr)]) *
-                binsize,
+                bin_size,
                 np.ones_like(np.unique(Js_dict['indices'][
-                    'trial' + str(tr)])) * tr + n * (num_tr + 1) + 1,
+                    'trial' + str(tr)])) * tr + n * (n_trials + 1) + 1,
                 ls='', ms=plot_params['ms'], marker='s',
                 markerfacecolor='none',
                 markeredgecolor='c')
-        if n < N - 1:
+        if n < n_neurons - 1:
             ax2.axhline((tr + 2) * (n + 1), lw=plot_params['lw'], color='k')
     ax2.set_ylim(0, (tr + 2) * (n + 1) + 1)
-    ax2.set_yticks([num_tr + 1, 2*num_tr + 1])
-    ax2.set_yticklabels([1, num_tr], fontsize=plot_params['fsize'])
-    ax2.set_xlim(0, (max(t_winpos) + winsize).rescale('ms').magnitude)
+    ax2.set_yticks([n_trials + 1, 2*n_trials + 1])
+    ax2.set_yticklabels([1, n_trials], fontsize=plot_params['fsize'])
+    ax2.set_xlim(0, (max(t_winpos) + win_size).rescale('ms').magnitude)
     ax2.set_ylabel('Trial', fontsize=plot_params['fsize'])
     for key in plot_params['events'].keys():
         for e_val in plot_params['events'][key]:
@@ -294,13 +275,13 @@ def plot_ue(data, Js_dict, sig_level, binsize, winsize, winstep,
     print('plotting emp. and exp. coincidences rate ...')
     ax3 = plt.subplot(num_row, 1, 4, sharex=ax0)
     ax3.set_title('Coincidence Rates')
-    ax3.plot(t_winpos + winsize / 2.,
-             Js_dict['n_emp'] / (winsize.rescale('s').magnitude * num_tr),
+    ax3.plot(t_winpos + win_size / 2.,
+             Js_dict['n_emp'] / (win_size.rescale('s').magnitude * n_trials),
              label='Empirical', lw=plot_params['lw'], color='c')
-    ax3.plot(t_winpos + winsize / 2.,
-             Js_dict['n_exp'] / (winsize.rescale('s').magnitude * num_tr),
+    ax3.plot(t_winpos + win_size / 2.,
+             Js_dict['n_exp'] / (win_size.rescale('s').magnitude * n_trials),
              label='Expected', lw=plot_params['lw'], color='m')
-    ax3.set_xlim(0, (max(t_winpos) + winsize).rescale('ms').magnitude)
+    ax3.set_xlim(0, (max(t_winpos) + win_size).rescale('ms').magnitude)
     ax3.set_ylabel('(1/s)', fontsize=plot_params['fsize'])
     ax3.legend(fontsize=plot_params['fsize']//2)
     YTicks = ax3.get_ylim()
@@ -313,9 +294,9 @@ def plot_ue(data, Js_dict, sig_level, binsize, winsize, winstep,
     print('plotting Surprise ...')
     ax4 = plt.subplot(num_row, 1, 5, sharex=ax0)
     ax4.set_title('Statistical Significance')
-    ax4.plot(t_winpos + winsize / 2., Js_dict['Js'], lw=plot_params['lw'],
+    ax4.plot(t_winpos + win_size / 2., Js_dict['Js'], lw=plot_params['lw'],
              color='k')
-    ax4.set_xlim(0, (max(t_winpos) + winsize).rescale('ms').magnitude)
+    ax4.set_xlim(0, (max(t_winpos) + win_size).rescale('ms').magnitude)
     ax4.axhline(Js_sig, ls='-', color='r')
     ax4.axhline(-Js_sig, ls='-', color='g')
     ax4.text(t_winpos[30], Js_sig + 0.3, '$\\alpha +$', color='r')
@@ -332,11 +313,11 @@ def plot_ue(data, Js_dict, sig_level, binsize, winsize, winstep,
     print('plotting UEs ...')
     ax5 = plt.subplot(num_row, 1, 6, sharex=ax0)
     ax5.set_title('Unitary Events')
-    for n in range(N):
-        for tr, data_tr in enumerate(data):
+    for n in range(n_neurons):
+        for tr, data_tr in enumerate(spiketrains):
             ax5.plot(data_tr[n].rescale('ms').magnitude,
                      np.ones_like(data_tr[n].magnitude) *
-                     tr + n * (num_tr + 1) + 1, '.',
+                     tr + n * (n_trials + 1) + 1, '.',
                      markersize=0.5, color='k')
             js_nonnan = Js_dict['Js'][~np.isnan(Js_dict['Js'])]
             sig_idx_win = np.where(js_nonnan >= Js_sig)[0]
@@ -346,21 +327,21 @@ def plot_ue(data, Js_dict, sig_level, binsize, winsize, winstep,
                     xx = []
                     for j in sig_idx_win:
                         xx = np.append(xx, x[np.where(
-                            (x * binsize >= t_winpos[j]) &
-                            (x * binsize < t_winpos[j] + winsize))])
+                            (x * bin_size >= t_winpos[j]) &
+                            (x * bin_size < t_winpos[j] + win_size))])
                     ax5.plot(
                         np.unique(
-                            xx) * binsize,
+                            xx) * bin_size,
                         np.ones_like(np.unique(xx)) *
-                        tr + n * (num_tr + 1) + 1,
+                        tr + n * (n_trials + 1) + 1,
                         ms=plot_params['ms'], marker='s', ls='', mfc='none',
                         mec='r')
-        if n < N - 1:
+        if n < n_neurons - 1:
             ax5.axhline((tr + 2) * (n + 1), lw=plot_params['lw'], color='k')
-    ax5.set_yticks([num_tr + 1, 2*num_tr + 1])
-    ax5.set_yticklabels([1, num_tr], fontsize=plot_params['fsize'])
+    ax5.set_yticks([n_trials + 1, 2*n_trials + 1])
+    ax5.set_yticklabels([1, n_trials], fontsize=plot_params['fsize'])
     ax5.set_ylim(0, (tr + 2) * (n + 1) + 1)
-    ax5.set_xlim(0, (max(t_winpos) + winsize).rescale('ms').magnitude)
+    ax5.set_xlim(0, (max(t_winpos) + win_size).rescale('ms').magnitude)
     ax5.set_ylabel('Trial', fontsize=plot_params['fsize'])
     ax5.set_xlabel(f'Time ({t_start.dimensionality.string})',
                    fontsize=plot_params['fsize'])

--- a/viziphant/unitary_event_analysis.py
+++ b/viziphant/unitary_event_analysis.py
@@ -273,8 +273,9 @@ def plot_ue(spiketrains, Js_dict, significance_level=0.05,
                      Js_dict['rate_avg'][:, n].rescale('Hz'),
                      label=f"Unit {plot_params['unit_real_ids'][n]}",
                      lw=plot_params['lw'])
-    axes[1].set_ylabel('(1/s)', fontsize=plot_params['fsize'])
+    axes[1].set_ylabel('Hz', fontsize=plot_params['fsize'])
     axes[1].legend(fontsize=plot_params['fsize'] // 2, loc='upper right')
+    axes[1].locator_params(axis='y', tight=True, nbins=3)
 
     axes[2].set_title('Coincident Events')
     for n in range(n_neurons):
@@ -298,10 +299,9 @@ def plot_ue(spiketrains, Js_dict, significance_level=0.05,
                  Js_dict['n_exp'] / (
                              win_size.rescale('s').magnitude * n_trials),
                  label='Expected', lw=plot_params['lw'], color='m')
-    axes[3].set_ylabel('(1/s)', fontsize=plot_params['fsize'])
+    axes[3].set_ylabel('Hz', fontsize=plot_params['fsize'])
     axes[3].legend(fontsize=plot_params['fsize'] // 2, loc='upper right')
-    yticks_ax3 = axes[3].get_ylim()
-    axes[3].set_yticks([0, yticks_ax3[1] / 2, yticks_ax3[1]])
+    axes[3].locator_params(axis='y', tight=True, nbins=3)
 
     axes[4].set_title('Statistical Significance')
     axes[4].plot(t_winpos + win_size / 2., Js_dict['Js'], lw=plot_params['lw'],
@@ -354,7 +354,7 @@ def plot_ue(spiketrains, Js_dict, significance_level=0.05,
                                           fill_value=n * n_trials + tr),
                              ms=plot_params['ms'], marker='s', ls='',
                              mfc='none', mec='r')
-    axes[5].set_xlabel(f'Time ({t_start.dimensionality.string})',
+    axes[5].set_xlabel(f'Time ({t_winpos.dimensionality})',
                        fontsize=plot_params['fsize'])
     for key in plot_params['events'].keys():
         for event_time in plot_params['events'][key]:

--- a/viziphant/unitary_event_analysis.py
+++ b/viziphant/unitary_event_analysis.py
@@ -220,7 +220,7 @@ def plot_ue(spiketrains, Js_dict, significance_level=0.05,
     if plot_params['unit_real_ids'] is None:
         plot_params['unit_real_ids'] = ['not specified'] * n_neurons
     if len(plot_params['unit_real_ids']) != n_neurons:
-        raise ValueError('length of unit_ids should be' +
+        raise ValueError('length of unit_ids should be ' +
                          'equal to number of neurons!')
     plt.rcParams.update({'font.size': plot_params['fsize']})
     ls = '-'

--- a/viziphant/unitary_event_analysis.py
+++ b/viziphant/unitary_event_analysis.py
@@ -60,7 +60,7 @@ plot_params_default = {
 
 
 def plot_ue(spiketrains, Js_dict, significance_level=0.05,
-            **plot_params_user):
+            **plot_params):
     """
     Plots the results of pairwise unitary event analysis as a column of six
     subplots, comprised of raster plot, peri-stimulus time histogram,
@@ -78,8 +78,8 @@ def plot_ue(spiketrains, Js_dict, significance_level=0.05,
         :func:`elephant.unitary_event_analysis.jointJ_window_analysis`
         function. The values of each key has the shape of:
 
-          * different pattern hash --> 0-axis;
-          * different window --> 1-axis.
+          * different window --> 0-axis.
+          * different pattern hash --> 1-axis;
 
         Dictionary keys:
 
@@ -97,7 +97,7 @@ def plot_ue(spiketrains, Js_dict, significance_level=0.05,
     significance_level : float
         The significance threshold used to determine which coincident events
         are classified as unitary events within a window.
-    **plot_params_user
+    **plot_params
         User-defined plotting parameters used to update the default plotting
         parameter values. The valid keys:
 
@@ -214,6 +214,7 @@ def plot_ue(spiketrains, Js_dict, significance_level=0.05,
     Js_sig = ue.jointJ(significance_level)
 
     # figure format
+    plot_params_user = plot_params
     plot_params = plot_params_default.copy()
     plot_params.update(plot_params_user)
     if plot_params['unit_real_ids'] is None:


### PR DESCRIPTION
* Fixes #24 
* Fixes the [unreported bug](https://github.com/INM-6/viziphant/blob/master/viziphant/unitary_event_analysis.py#L341-L350) when `Js` values contain NaNs, leading to (possibly) shifted unitary event red marks. The fix was to change `t_winpos[j] -> t_winpos[js_nonnan][j]` so that `sig_idx_win` and `t_winpos` indices become aligned.
* Added an example to the documentation.
* Refactored the all-mighty code for axes plotting routines.

Requires https://github.com/NeuralEnsemble/elephant/pull/387, which simplifies the API significantly by storing the input parameters.

Potential improvements, disregarded in this PR:
* rename `Js_dict` to a more meaningful name;
* use `viziphant.events.add_event` function to plot events instead of custom error-prone script, included in the function body.
* optimize axes[5] unitary events mask selection by stripping off the quantity units.

P.S. The build fails because, of course, it expects the changes in elephant to be already in the master branch.