### PR TITLE
GPFA spikeplay

### DIFF
--- a/viziphant/gpfa.py
+++ b/viziphant/gpfa.py
@@ -783,7 +783,7 @@ def plot_trajectories_spikeplay(spiketrains,
         bin_id = int(iteration)
         residual = iteration - bin_id
         data = data_orig[:, :bin_id]
-        if bin_id != n_steps:
+        if bin_id < data_orig.shape[1]:
             # append an intermediate point
             vec = data_orig[:, bin_id] - data_orig[:, bin_id - 1]
             data = np.c_[data,
@@ -812,8 +812,9 @@ def plot_trajectories_spikeplay(spiketrains,
         artists = [slider, *lines_trials, *lines_groups]
         return artists
 
-    n_steps = data[0].shape[1]  # the num. of bins
-    time_steps = np.arange(speed, n_steps + speed, speed)
+    # GPFA implementation allows different n_bins. So does viziphant.
+    n_time_bins = gpfa_instance.transform_info['num_bins'].max()
+    time_steps = np.arange(speed, n_time_bins + speed, speed)
     interval = speed * gpfa_instance.bin_size.rescale('ms').item()
     spikeplay = animation.FuncAnimation(fig, animate, frames=time_steps,
                                         interval=interval, blit=True,

--- a/viziphant/gpfa.py
+++ b/viziphant/gpfa.py
@@ -595,7 +595,7 @@ def plot_trajectories_spikeplay(spiketrains,
                                 trial_grouping_dict=None,
                                 colors='grey',
                                 plot_group_averages=False,
-                                transparent_spikes=False,
+                                hide_irrelevant_neurons=False,
                                 plot_args_single={'linewidth': 0.3,
                                                   'alpha': 0.4,
                                                   'linestyle': '-'},
@@ -693,7 +693,7 @@ def plot_trajectories_spikeplay(spiketrains,
         If True, trajectories of those trials belonging together specified
         in the trial_grouping_dict are averaged and plotted.
         Default: False
-    transparent_spikes : bool, optional
+    hide_irrelevant_neurons : bool, optional
         If True, neural activity will be shaded according to the influence
         of a neuron on the chosen latent `dimensions`. The influence is
         estimated as a normalized L1-norm of the columns of the pseudo-inverse
@@ -754,7 +754,7 @@ def plot_trajectories_spikeplay(spiketrains,
     ax2 = fig.add_subplot(1, 2, 2, projection=projection, aspect='auto',
                           title="GPFA latent trajectories")
 
-    if transparent_spikes:
+    if hide_irrelevant_neurons:
         Corth = gpfa_instance.params_estimated['Corth']
         Corth_inv = np.linalg.pinv(Corth)
         l1_norm = np.linalg.norm(Corth_inv[dimensions], ord=1, axis=0)

--- a/viziphant/gpfa.py
+++ b/viziphant/gpfa.py
@@ -876,13 +876,11 @@ def _set_title_dimensions_vs_time(ax,
 
         # percentage of variance of the dimensionality reduced data
         # that is explained by this latent variable
-        variances = [np.var(np.hstack(data)[i, :]) for
-                     i in range(gpfa_instance.x_dim)]
+        variances = np.var(np.hstack(data), axis=1)
         total_variance = np.sum(variances)
-        explained_variance = np.round(
-            variances[latent_variable_idx]/total_variance*100, 2)
+        explained_variance = variances[latent_variable_idx] / total_variance
 
-        title = title + f'% exp. var.: {explained_variance} %'
+        title = title + f'% exp. var.: {explained_variance * 100:.2f} %'
     else:
         title = r"${{\mathbf{{x}}}}_{{{},:}}$".format(latent_variable_idx)
 

--- a/viziphant/gpfa.py
+++ b/viziphant/gpfa.py
@@ -749,7 +749,8 @@ def plot_trajectories_spikeplay(spiketrains,
     # initialize figure and axis
     fig = plt.figure(**figure_kwargs)
     ax1 = fig.add_subplot(1, 2, 1)
-    ax2 = fig.add_subplot(1, 2, 2, projection=projection, aspect='auto')
+    ax2 = fig.add_subplot(1, 2, 2, projection=projection, aspect='auto',
+                          title="GPFA latent trajectories")
 
     if transparent_spikes:
         Corth = gpfa_instance.params_estimated['Corth']

--- a/viziphant/gpfa.py
+++ b/viziphant/gpfa.py
@@ -293,13 +293,9 @@ def plot_dimensions_vs_time(returned_data,
     if trial_grouping_dict is None:
         trial_grouping_dict = {}
     colors = _check_colors(colors, trial_grouping_dict, n_trials=data.shape[0])
-    # infer n_trial from shape of the data
-    n_trials = data.shape[0]
-    # infer n_time_bins from maximal number of bins
-    # TODO: deal with varying number of bins over trials?
-    n_time_bins = gpfa_instance.transform_info['num_bins'].max()
 
-    times = np.arange(1, n_time_bins + 1) * gpfa_instance.bin_size
+    n_trials = data.shape[0]
+    bin_size = gpfa_instance.bin_size.item()
 
     for dimension_index, axis in zip(dimensions, np.ravel(axes)):
         if plot_single_trajectories:
@@ -310,7 +306,8 @@ def plot_dimensions_vs_time(returned_data,
                                                      trial_idx)
 
                 # plot single trial trajectories
-                axis.plot(times.magnitude,
+                times = np.arange(1, dat.shape[1] + 1) * bin_size
+                axis.plot(times,
                           dat[dimension_index, :],
                           color=colors[key_id],
                           label=trial_type,
@@ -319,7 +316,8 @@ def plot_dimensions_vs_time(returned_data,
         if plot_group_averages:
             for color, trial_type in zip(colors, trial_grouping_dict.keys()):
                 group_average = data[trial_grouping_dict[trial_type]].mean()
-                axis.plot(times.magnitude,
+                times = np.arange(1, group_average.shape[1] + 1) * bin_size
+                axis.plot(times,
                           group_average[dimension_index],
                           color=color,
                           label=trial_type,
@@ -336,7 +334,7 @@ def plot_dimensions_vs_time(returned_data,
     plt.tight_layout()
 
     for axis in axes[-1, :]:
-        axis.set_xlabel(f'Time ({times.dimensionality})')
+        axis.set_xlabel(f'Time ({gpfa_instance.bin_size.dimensionality})')
 
     return fig, axes
 

--- a/viziphant/gpfa.py
+++ b/viziphant/gpfa.py
@@ -927,15 +927,15 @@ def _set_axis_labels_trajectories(ax,
                                   orthonormalized_dimensions,
                                   dimensions):
     if orthonormalized_dimensions:
-        str1 = r"$\tilde{{\mathbf{{x}}}}_{{{},:}}$".format(dimensions[0])
-        str2 = r"$\tilde{{\mathbf{{x}}}}_{{{},:}}$".format(dimensions[1])
+        str1 = rf"$\tilde{{\mathbf{{x}}}}_{{{dimensions[0]}}}$"
+        str2 = rf"$\tilde{{\mathbf{{x}}}}_{{{dimensions[1]}}}$"
         if len(dimensions) == 3:
-            str3 = r"$\tilde{{\mathbf{{x}}}}_{{{},:}}$".format(dimensions[2])
+            str3 = rf"$\tilde{{\mathbf{{x}}}}_{{{dimensions[2]}}}$"
     else:
-        str1 = r"${{\mathbf{{x}}}}_{{{},:}}$".format(dimensions[0])
-        str2 = r"${{\mathbf{{x}}}}_{{{},:}}$".format(dimensions[1])
+        str1 = rf"${{\mathbf{{x}}}}_{{{dimensions[0]}}}$"
+        str2 = rf"${{\mathbf{{x}}}}_{{{dimensions[1]}}}$"
         if len(dimensions) == 3:
-            str3 = r"${{\mathbf{{x}}}}_{{{},:}}$".format(dimensions[2])
+            str3 = rf"${{\mathbf{{x}}}}_{{{dimensions[2]}}}$"
     ax.set_xlabel(str1, fontsize=16)
     ax.set_ylabel(str2, fontsize=16)
     if len(dimensions) == 3:

--- a/viziphant/gpfa.py
+++ b/viziphant/gpfa.py
@@ -361,7 +361,8 @@ def plot_trajectories(returned_data,
                                          'linestyle': 'dashdot'},
                       plot_args_marker_start={'marker': 'p',
                                               'markersize': 10,
-                                              'label': 'start'}):
+                                              'label': 'start'},
+                      figure_kwargs=dict()):
 
     """
     This function allows for 2D and 3D visualization of the latent space
@@ -467,6 +468,9 @@ def plot_trajectories(returned_data,
     plot_args_marker_start : dict, optional
         Arguments dictionary passed to ax.plot() for the marker of the
         average trajectory start.
+    figure_kwargs : dict, optional
+        Figure parameters in ``plt.figure()``.
+        Default: {}
 
     Returns
     -------
@@ -529,7 +533,7 @@ def plot_trajectories(returned_data,
     n_trials = data.shape[0]
 
     # initialize figure and axis
-    fig = plt.figure()
+    fig = plt.figure(**figure_kwargs)
     axes = fig.gca(projection=projection, aspect='auto')
 
     # loop over trials
@@ -603,7 +607,8 @@ def plot_trajectories_spikeplay(spiketrains,
                                                    'linestyle': 'dashdot'},
                                 plot_args_marker_start={'marker': 'p',
                                                         'markersize': 10,
-                                                        'label': 'start'}):
+                                                        'label': 'start'},
+                                figure_kwargs=dict()):
     """
     This function allows for 2D and 3D visualization of the latent space
     variables identified by the GPFA.
@@ -693,6 +698,9 @@ def plot_trajectories_spikeplay(spiketrains,
     plot_args_marker_start : dict, optional
         Arguments dictionary passed to ax.plot() for the marker of the
         average trajectory start.
+    figure_kwargs : dict, optional
+        Figure parameters in ``plt.figure()``.
+        Default: {}
 
     Returns
     -------
@@ -713,7 +721,7 @@ def plot_trajectories_spikeplay(spiketrains,
     n_trials_to_plot = min(n_trials, n_trials_to_plot)
 
     # initialize figure and axis
-    fig = plt.figure()
+    fig = plt.figure(**figure_kwargs)
     ax1 = fig.add_subplot(1, 2, 1)
     ax2 = fig.add_subplot(1, 2, 2, projection=projection, aspect='auto')
 

--- a/viziphant/gpfa.py
+++ b/viziphant/gpfa.py
@@ -730,6 +730,14 @@ def plot_trajectories_spikeplay(spiketrains,
     fig : matplotlib.figure.Figure
     axes : matplotlib.axes.Axes
     spikeplay : matplotlib.animation.FuncAnimation
+        Matplotlib animation that can be saved in a GIF or a video file.
+
+        .. code-block:: python
+
+            import matplotlib.animation as animation
+            spikeplay.save("gpfa.gif")
+            writergif = animation.FFMpegWriter(fps=60)
+            spikeplay.save("gpfa.mov", writer=writergif)
 
     """
     # Input spiketrains that were binned must share the same t_start and t_stop

--- a/viziphant/gpfa.py
+++ b/viziphant/gpfa.py
@@ -487,6 +487,7 @@ def plot_trajectories(returned_data,
     >>> import quantities as pq
     >>> from elephant.gpfa import GPFA
     >>> from elephant.spike_train_generation import homogeneous_poisson_process
+    >>> from viziphant.gpfa import plot_trajectories
     >>> data = []
     >>> for trial in range(50):
     >>>     n_channels = 20
@@ -494,7 +495,7 @@ def plot_trajectories(returned_data,
     ...                                      size=n_channels) * pq.Hz
     >>>     spike_times = [homogeneous_poisson_process(rate=rate)
     ...                    for rate in firing_rates]
-    >>>     data.append((trial, spike_times))
+    >>>     data.append(spike_times)
     ...
     >>> gpfa = GPFA(bin_size=20*pq.ms, x_dim=8)
     >>> gpfa.fit(data)
@@ -511,14 +512,9 @@ def plot_trajectories(returned_data,
     >>> plot_trajectories(
     ...        results,
     ...        gpfa,
-    ...        block_with_cut_trials=None,
-    ...        relevant_events=None,
     ...        dimensions=[0,1,2],
     ...        trial_grouping_dict=trial_grouping_dict,
-    ...        plot_group_averages=False,
-    ...        n_trials_to_plot=200,
-    ...        plot_args_single={'linewidth': 0.8,
-    ...                          'alpha': 0.4, 'linestyle': '-'})
+    ...        plot_group_averages=True)
 
     """
     # prepare the input
@@ -657,6 +653,9 @@ def plot_trajectories_spikeplay(spiketrains,
         List specifying the indices of the dimensions to use for the
         2D or 3D plot.
         Default: [0, 1]
+    speed : float, optional
+        The animation speed.
+        Default: 0.2
     orthonormalized_dimensions : bool, optional
         Boolean which specifies whether to plot the orthonormalized latent
         state space dimension corresponding to the entry 'latent_variable_orth'

--- a/viziphant/gpfa.py
+++ b/viziphant/gpfa.py
@@ -607,6 +607,7 @@ def plot_trajectories_spikeplay(spiketrains,
                                                         'label': 'start'},
                                 eventplot_kwargs=dict(),
                                 slider_kwargs=dict(),
+                                animation_kwargs=dict(blit=True, repeat=True),
                                 figure_kwargs=dict()):
     r"""
     This function allows for 2D and 3D visualization of the latent space
@@ -718,6 +719,8 @@ def plot_trajectories_spikeplay(spiketrains,
     slider_kwargs : dict, optional
         Arguments dictionary for a slider passed to ``ax.axvline()``.
         Default: {}
+    animation_kwargs : dict, optional
+        Arguments dictionary passed to ``animation.FuncAnimation()``.
     figure_kwargs : dict, optional
         Arguments dictionary passed to ``plt.figure()``.
         Default: {}
@@ -845,8 +848,7 @@ def plot_trajectories_spikeplay(spiketrains,
     time_steps = np.arange(speed, n_time_bins + speed, speed)
     interval = speed * gpfa_instance.bin_size.rescale('ms').item()
     spikeplay = animation.FuncAnimation(fig, animate, frames=time_steps,
-                                        interval=interval, blit=True,
-                                        repeat=True)
+                                        interval=interval, **animation_kwargs)
 
     return fig, [ax1, ax2], spikeplay
 


### PR DESCRIPTION
Added `plot_trajectories_spikeplay` function that produces an animated visualization of latent variables dynamics alongside a rasterpot.

The example below is taken from Simon's tutorial.

```python
import matplotlib.animation as animation
import matplotlib.pyplot as plt

from viziphant.gpfa import plot_trajectories_spikeplay

plt.style.use('dark_background')
fig, axes, spikeplay = plot_trajectories_spikeplay(spiketrains,
                                                   returned_data=returned_data,
                                                   gpfa_instance=gpfa_instance,
                                                   trial_grouping_dict=trial_grouping_dict,
                                                   plot_group_averages=True,
                                                   n_trials_to_plot=20,
                                                   speed=0.05,
                                                   dimensions=[0, 2],
                                                   figure_kwargs=dict(figsize=(6, 3)),
                                                   eventplot_kwargs=dict(lw=0.9),
                                                   slider_kwargs=dict(lw=0.5))
axes[1].get_legend().remove()
writergif = animation.FFMpegWriter(fps=60)
spikeplay.save('gpfa.mp4', writer=writergif)
spikeplay.save('gpfa.gif')
plt.show()
```

![gpfa_fast](https://user-images.githubusercontent.com/7688337/106108395-7a295200-6148-11eb-827c-332a6404e10b.gif)
