### PR TITLE
Housekeeping CI Github actions

### DIFF
--- a/.github/workflows/CI_actions.yml
+++ b/.github/workflows/CI_actions.yml
@@ -1,0 +1,62 @@
+# This workflow will setup GitHub-hosted runners and install the required dependencies for viziphant documentation.
+# On a pull requests and on pushes to master it will build and create the documentation .
+
+name: Viziphant-tests
+# define events that trigger workflow 'Viziphant-tests'
+on:
+  # run on pull requests to master branch
+  pull_request:
+    branches: [master]
+    types: [synchronize, opened, reopened, ready_for_review]
+    
+  # run on pushes to master branch
+  push:
+    #branches: [master]
+    
+# jobs define the steps that will be executed on the runner
+jobs:
+  
+  # install dependencies for the documentation and build .html
+  docs:
+       runs-on: ${{ matrix.os }}
+       strategy:
+       
+        matrix:
+          # OS [ubuntu-latest, macos-latest, windows-latest]
+          os: [ubuntu-latest]
+          # relevant python versions for viziphant: [3.6, 3.7, 3.8]
+          python-version: [3.6, 3.7, 3.8]
+          
+        # do not cancel all in-progress jobs if any matrix job fails
+        fail-fast: false
+
+       steps:
+
+       - name: Get current year-month
+         id: date
+         run: echo "::set-output name=date::$(date +'%Y-%m')"
+
+       - uses: actions/checkout@v2
+       
+       - name: Set up Python ${{ matrix.python-version }}
+         uses: actions/setup-python@v2
+         with:
+            python-version: ${{ matrix.python-version }}
+            
+       - name: Cache pip
+         uses: actions/cache@v2
+         with:
+            path: ~/.cache/pip
+            # Look to see if there is a cache hit for the corresponding requirements files
+            key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-docs.txt') }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/environment.yml') }}-${{ steps.date.outputs.date }}
+
+       - name: Install dependencies
+         run: |
+            python -m pip install --upgrade pip
+            pip install -r requirements/requirements-docs.txt
+            pip install -r requirements/requirements.txt
+            pip install .
+       - name: make html
+         run: |
+            cd doc
+            make html

--- a/.github/workflows/CI_actions.yml
+++ b/.github/workflows/CI_actions.yml
@@ -2,7 +2,7 @@
 # On pull requests and on pushes to master it will build the documentation .
 
 
-name: Viziphant-tests
+name: tests
 # define events that trigger workflow 'Viziphant-tests'
 on:
   # run on pull requests to master branch

--- a/.github/workflows/CI_actions.yml
+++ b/.github/workflows/CI_actions.yml
@@ -57,7 +57,6 @@ jobs:
             pip install -r requirements/requirements.txt
             pip install .
             conda update conda
-            conda env update --file requirements/environment.yml --name base
             conda install -c conda-forge pandoc
             # run notebooks
             sed -i -E "s/nbsphinx_execute *=.*/nbsphinx_execute = 'always'/g" doc/conf.py

--- a/.github/workflows/CI_actions.yml
+++ b/.github/workflows/CI_actions.yml
@@ -1,5 +1,5 @@
 # This workflow will setup GitHub-hosted runners and install the required dependencies for viziphant documentation.
-# On a pull requests and on pushes to master it will build and create the documentation .
+# On pull requests and on pushes to master it will build the documentation .
 
 name: Viziphant-tests
 # define events that trigger workflow 'Viziphant-tests'
@@ -48,7 +48,7 @@ jobs:
          with:
             path: ~/.cache/pip
             # Look to see if there is a cache hit for the corresponding requirements files
-            key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-docs.txt') }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/environment.yml') }}-${{ steps.date.outputs.date }}
+            key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-docs.txt') }}-${{ hashFiles('**/requirements.txt') }}-${{ steps.date.outputs.date }}
 
        - name: Install dependencies
          run: |

--- a/.github/workflows/CI_actions.yml
+++ b/.github/workflows/CI_actions.yml
@@ -8,25 +8,25 @@ on:
   pull_request:
     branches: [master]
     types: [synchronize, opened, reopened, ready_for_review]
-    
+
   # run on pushes to master branch
   push:
     #branches: [master]
-    
+
 # jobs define the steps that will be executed on the runner
 jobs:
-  
+
   # install dependencies for the documentation and build .html
   docs:
        runs-on: ${{ matrix.os }}
        strategy:
-       
+
         matrix:
           # OS [ubuntu-latest, macos-latest, windows-latest]
           os: [ubuntu-latest]
           # relevant python versions for viziphant: [3.6, 3.7, 3.8]
           python-version: [3.6, 3.7, 3.8]
-          
+
         # do not cancel all in-progress jobs if any matrix job fails
         fail-fast: false
 
@@ -37,12 +37,12 @@ jobs:
          run: echo "::set-output name=date::$(date +'%Y-%m')"
 
        - uses: actions/checkout@v2
-       
+
        - name: Set up Python ${{ matrix.python-version }}
          uses: actions/setup-python@v2
          with:
             python-version: ${{ matrix.python-version }}
-            
+
        - name: Cache pip
          uses: actions/cache@v2
          with:
@@ -56,7 +56,13 @@ jobs:
             pip install -r requirements/requirements-docs.txt
             pip install -r requirements/requirements.txt
             pip install .
+            conda update conda
+            conda env update --file requirements/environment.yml --name base
+            conda install -c conda-forge pandoc
+            # run notebooks
+            sed -i -E "s/nbsphinx_execute *=.*/nbsphinx_execute = 'always'/g" doc/conf.py
        - name: make html
          run: |
+            python --version
             cd doc
             make html

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/INM-6/viziphant.svg?branch=master)](https://travis-ci.org/INM-6/viziphant)
 [![Documentation Status](https://readthedocs.org/projects/viziphant/badge/?version=latest)](https://viziphant.readthedocs.io/en/latest/?badge=latest)
 [![![PyPi]](https://img.shields.io/pypi/v/viziphant)](https://pypi.org/project/viziphant/)
+[![Viziphant-tests](https://github.com/INM-6/viziphant/actions/workflows/CI_actions.yml/badge.svg)](https://github.com/INM-6/viziphant/actions/workflows/CI_actions.yml)
 
 A Python module for easy visualization of [Neo](https://github.com/NeuralEnsemble/python-neo) objects and [Elephant](https://github.com/NeuralEnsemble/elephant) results.
 


### PR DESCRIPTION
# Removed `environment.yml` from cache key-hash and minor changes to comments.
This should be safe to merge after #39 since it only changes the way a hash is calculated for the pip cache.

This hash key allows GitHub actions to load a specific pip cache identified with the key. Since this key is calculated with:

`key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-docs.txt') }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/environment.yml') }}-${{ steps.date.outputs.date }}`.

The cache will be reset on any changes to the requirements (and every month using the date),since `environment.yml` will be removed in #39, it should  be removed here aswell.