### PR TITLE
Fix: plot for ASSET documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,6 +14,12 @@ from datetime import date
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('.'))
 
+# -- Setup environment variables for elephant --------------------------------
+# set the following environment variables to ensure execution of plots when
+# building docs. This is of importance in connection with elephant modules
+# using OpenCL (pyopencl) or CUDA (pycuda).
+
+os.environ["ELEPHANT_USE_OPENCL"] = "0"
 
 # -- Project information -----------------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,6 +20,7 @@ sys.path.insert(0, os.path.abspath('.'))
 # using OpenCL (pyopencl) or CUDA (pycuda).
 
 os.environ["ELEPHANT_USE_OPENCL"] = "0"
+os.environ["ELEPHANT_USE_CUDA"] = "0"
 
 # -- Project information -----------------------------------------------------
 

--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -2,3 +2,4 @@ numpydoc>=1.1.0
 sphinx>=3.3.0
 sphinx-tabs>=1.1.13
 sphinxcontrib-bibtex==1.0.0
+elephant[extras]>=0.9.0 # needed for sphinx to create plots for GPFA and ASSET


### PR DESCRIPTION
# plot for ASSET `plot_synchronous_events`

The plot created in the ASSET documentation 'viziphant.asset.plot_synchronous_events` is now displayed.

Check result  here: https://viziphant-experimental.readthedocs.io/en/fix-asset_plot/toctree/asset/viziphant.asset.plot_synchronous_events.html#viziphant.asset.plot_synchronous_events

---
Changes:
- added elephant[extras] to `requirements/requirements-docs.txt`
- added set environment variable to `doc/conf.py`