### PR TITLE
fix display of project description on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     description="Viziphant is a package for the visualization of the analysis"
                 "results of electrophysiology data in Python",
     long_description=long_description,
+    long_description_content_type="text/markdown",
     license="BSD",
     url='https://github.com/INM-6/viziphant',
     classifiers=[


### PR DESCRIPTION
### Display of `README.md`

The project description on PyPI is created using the `README.md`. Currently the raw markdown code is displayed on https://pypi.org/project/viziphant/. If one compares with e.g. https://pypi.org/project/neo/, the difference is obvious (Neo uses `.rst` reStructuredText). 

**Changes**
Added `long_description_content_type = text/markdown` to `setup.py`.
See this guide for reference: https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/