### PR TITLE
Fix/remove py 36

### DIFF
--- a/.github/workflows/CI_actions.yml
+++ b/.github/workflows/CI_actions.yml
@@ -12,7 +12,7 @@ on:
 
   # run on pushes to master branch
   push:
-    #branches: [master]
+  #branches: [master]
 
 # jobs define the steps that will be executed on the runner
 jobs:
@@ -25,8 +25,8 @@ jobs:
         matrix:
           # OS [ubuntu-latest, macos-latest, windows-latest]
           os: [ubuntu-latest]
-          # relevant python versions for viziphant: [3.6, 3.7, 3.8]
-          python-version: [3.6, 3.7, 3.8]
+          # relevant python versions for viziphant: [3.7, 3.8, 3.9]
+          python-version: [3.7, 3.8, 3.9, '3.10']
 
         # do not cancel all in-progress jobs if any matrix job fails
         fail-fast: false

--- a/.github/workflows/CI_actions.yml
+++ b/.github/workflows/CI_actions.yml
@@ -26,7 +26,7 @@ jobs:
           # OS [ubuntu-latest, macos-latest, windows-latest]
           os: [ubuntu-latest]
           # relevant python versions for viziphant: [3.7, 3.8, 3.9]
-          python-version: [3.7, 3.8, 3.9, '3.10']
+          python-version: [3.7, 3.8, 3.9]
 
         # do not cancel all in-progress jobs if any matrix job fails
         fail-fast: false


### PR DESCRIPTION
This PR removes python 3.6 from and adds 3.9 to GitHub actions CI workflow.
(Python 3.6 has reached its end-of-life at 23 Dec 2021.)