### PR TITLE
Add limit check to add_event

### DIFF
--- a/viziphant/events.py
+++ b/viziphant/events.py
@@ -66,6 +66,8 @@ def add_event(axes, event, key=None, rotation=40):
 
     # Get the limits of the last Axes object in the list
     x_lim_min, x_lim_max = axes[-1].get_xlim()
+    if x_lim_max < x_lim_min:
+        x_lim_min, x_lim_max = x_lim_max, x_lim_min
 
     for event_idx, time in enumerate(times):
         if x_lim_min <= time <= x_lim_max:

--- a/viziphant/events.py
+++ b/viziphant/events.py
@@ -63,13 +63,18 @@ def add_event(axes, event, key=None, rotation=40):
     """
     axes = np.atleast_1d(axes)
     times = event.times.magnitude
+
+    # Get the limits of the last Axes object in the list
+    x_lim_min, x_lim_max = axes[-1].get_xlim()
+
     for event_idx, time in enumerate(times):
-        if key is None:
-            label = event.labels[event_idx]
-        else:
-            label = event.array_annotations[key][event_idx]
-        for axis in axes:
-            axis.axvline(time, color='black')
-        axes[0].text(time, axes[0].get_ylim()[1], label,
-                     horizontalalignment='left',
-                     verticalalignment='bottom', rotation=rotation)
+        if x_lim_min <= time <= x_lim_max:
+            if key is None:
+                label = event.labels[event_idx]
+            else:
+                label = event.array_annotations[key][event_idx]
+            for axis in axes:
+                axis.axvline(time, color='black')
+            axes[0].text(time, axes[0].get_ylim()[1], label,
+                         horizontalalignment='left',
+                         verticalalignment='bottom', rotation=rotation)


### PR DESCRIPTION
When using the `add_event` function to add events to one or more plots (e.g., the output of `rasterplot_rates`), if the Axes limits were changed and the Event object includes events out of the boundaries, they will be plotted regardless, leading to an unpleasant visualization in notebooks (saving the figure to a file seems to work).

```
import quantities as pq
from elephant.spike_train_generation import StationaryPoissonProcess
from viziphant.rasterplot import rasterplot_rates
from viziphant.events import add_event
import matplotlib.pyplot as plt
import neo

spiketrains = StationaryPoissonProcess(rate=20 * pq.Hz, t_stop= 2 * pq.s).generate_n_spiketrains(20)

event = neo.Event([0.25, 1, 1.75], units=pq.s, labels=['event_1', 'event_2', 'event_3'])

fig, ax = plt.subplots(figsize=(20,15))
ax = rasterplot_rates(spiketrains, ax=ax)
ax[0].set_xlim([0, 0.75])
ax[1].set_xlim([0, 0.75])
add_event([ax[1], ax[0]], event)
```

![old](https://user-images.githubusercontent.com/42555442/179532729-082366ef-aca7-44a8-a8f4-af564dc9c83d.png)


This PR fixes this by adding boundary checks (with respect to the last Axes in the list passed as the function `axes` parameter).


![new](https://user-images.githubusercontent.com/42555442/179532861-3ca88dc6-0977-433e-ae6f-f0fe8b92956d.png)

