### PR TITLE
Add parameter to exclude labels from plotting in add_event

### DIFF
--- a/viziphant/events.py
+++ b/viziphant/events.py
@@ -17,7 +17,7 @@ import numpy as np
 import quantities as pq
 
 
-def add_event(axes, event, key=None, rotation=40):
+def add_event(axes, event, key=None, rotation=40, exclude=None):
     """
     Add event(s) to axes plot.
 
@@ -43,6 +43,9 @@ def add_event(axes, event, key=None, rotation=40):
     rotation : int, optional
         Text label rotation in degrees.
         Default : 40
+    exclude : list, optional
+        List of event labels that should not be plotted.
+        Default: None
 
     Examples
     --------
@@ -63,13 +66,19 @@ def add_event(axes, event, key=None, rotation=40):
     """
     axes = np.atleast_1d(axes)
     times = event.times.magnitude
+
+    if exclude is None:
+        exclude = []
+
     for event_idx, time in enumerate(times):
         if key is None:
             label = event.labels[event_idx]
         else:
             label = event.array_annotations[key][event_idx]
-        for axis in axes:
-            axis.axvline(time, color='black')
-        axes[0].text(time, axes[0].get_ylim()[1], label,
-                     horizontalalignment='left',
-                     verticalalignment='bottom', rotation=rotation)
+
+        if label not in exclude:
+            for axis in axes:
+                axis.axvline(time, color='black')
+            axes[0].text(time, axes[0].get_ylim()[1], label,
+                         horizontalalignment='left',
+                         verticalalignment='bottom', rotation=rotation)


### PR DESCRIPTION
Some events overlap in time. `add_event` currently plots all events defined, which can lead to overlapping and lack of readability in the output.

```
import quantities as pq
from elephant.spike_train_generation import StationaryPoissonProcess
from viziphant.rasterplot import rasterplot_rates
from viziphant.events import add_event
import matplotlib.pyplot as plt
import neo

spiketrains = StationaryPoissonProcess(rate=20 * pq.Hz, t_stop= 2 * pq.s).generate_n_spiketrains(20)

event = neo.Event([0.25, 1, 1, 1.75], units=pq.s, labels=['event_1', 'event_2', 'overlap_2', 'event_3'])

fig, ax = plt.subplots(figsize=(20,15))
ax = rasterplot_rates(spiketrains, ax=ax)
add_event([ax[1], ax[0]], event)
```

![old](https://user-images.githubusercontent.com/42555442/179536905-9b22dfdd-f1c3-4cf3-8302-e607553c3dcd.png)



This PR fixes that by adding an additional parameter `exclude`, where a list of labels not to plot are defined.

```
fig, ax = plt.subplots(figsize=(20,15))
ax = rasterplot_rates(spiketrains, ax=ax)
add_event([ax[1], ax[0]], event, exclude=['overlap_2'])
```

![new](https://user-images.githubusercontent.com/42555442/179535964-51955999-201f-40b3-b383-7233a628fa42.png)

