### PR TITLE
Fix: replace gca() with add_subplot() 

### DIFF
--- a/viziphant/gpfa.py
+++ b/viziphant/gpfa.py
@@ -569,7 +569,7 @@ def plot_trajectories(returned_data,
 
     # initialize figure and axis
     fig = plt.figure(**figure_kwargs)
-    axes = fig.gca(projection=projection, aspect='auto')
+    axes = fig.add_subplot(projection=projection, aspect='auto')
 
     # loop over trials
     for trial_idx in trials_to_plot:


### PR DESCRIPTION
This PR fixes #55 which occurred in relation with api changes in matplotlib 3.6.1.

**Bug:**
- `gca()` no longer accepts keyword arguments.

**Fix:**
- replace `gca()` with `add_subplot()`

