### PR TITLE
CI: update GitHub actions commands

### DIFF
--- a/.github/workflows/CI_actions.yml
+++ b/.github/workflows/CI_actions.yml
@@ -35,7 +35,7 @@ jobs:
 
        - name: Get current year-month
          id: date
-         run: echo "::set-output name=date::$(date +'%Y-%m')"
+         run: echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
 
        - uses: actions/checkout@v3
 


### PR DESCRIPTION
- the `set-output` command will be disabled 31st May 2023, see: [changelog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

This is similar to Neo PR [#1191](https://github.com/NeuralEnsemble/python-neo/pull/1191)