### PR TITLE
Fix/math in docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -128,3 +128,6 @@ htmlhelp_basename = 'viziphantdoc'
 
 # configuration for intersphinx: refer to Elephant
 intersphinx_mapping = {'viziphant': ('https://viziphant.readthedocs.io/en/latest/', None)}
+
+# path to bibtex_bibfiles
+bibtex_bibfiles = ['bib/viziphant.bib']

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,7 +40,6 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
-    'sphinx.ext.imgmath',
     'sphinx.ext.viewcode',
     'sphinx.ext.mathjax',
     'matplotlib.sphinxext.plot_directive',
@@ -91,6 +90,9 @@ html_theme_options = {
     'page_width': '1200px',  # default is 940
     'sidebar_width': '280px',  # default is 220
 }
+
+# The name of math_renderer extension for HTML output.
+html_math_renderer = 'mathjax'
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.

--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -1,5 +1,5 @@
 numpydoc>=1.1.0
 sphinx>=3.3.0
 sphinx-tabs>=1.1.13
-sphinxcontrib-bibtex==1.0.0
+sphinxcontrib-bibtex>1.0.0
 elephant[extras]>=0.9.0


### PR DESCRIPTION
# Bug
Documentation build with sphinx 5.3.0 (5.2.3 works) does not render math expressions properly, see:

See: https://viziphant.readthedocs.io/en/latest/toctree/gpfa/viziphant.gpfa.plot_trajectories_spikeplay.html#viziphant.gpfa.plot_trajectories_spikeplay

# Fix
In previous Sphinx releases, mathjax was the default html math renderer. With release 5.3.0, math expressions are no longer rendered properly, defining mathjax as the renderer fixes this Issue. 

- defined mathjax as html renderer
- removed sphinx extension `imgmath`

See result: https://viziphant--59.org.readthedocs.build/en/59/toctree/gpfa/viziphant.gpfa.plot_trajectories_spikeplay.html#viziphant.gpfa.plot_trajectories_spikeplay

See also:  https://github.com/NeuralEnsemble/elephant/pull/527