### PR TITLE
Fix: Remove title "viziphant" from navigation bar

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -83,30 +83,27 @@ autosummary_generate = True
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
 html_theme = 'alabaster'
 html_theme_options = {
     'font_family': 'Arial',
     'page_width': '1200px',  # default is 940
     'sidebar_width': '280px',  # default is 220
+    'logo': 'viziphant_logo_sidebar.png'  # add logo to sidebar
 }
 
 # The name of math_renderer extension for HTML output.
 html_math_renderer = 'mathjax'
 
-# The name of an image file (relative to this directory) to place at the top
-# of the sidebar.
-html_logo = 'images/viziphant_logo_sidebar.png'
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+# html_static_path = ['_static']
+html_static_path = ['images/viziphant_logo_sidebar.png']
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
 html_favicon = 'images/viziphant_favicon.ico'
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
 
 # Suppresses  wrong numpy doc warnings
 # see here https://github.com/phn/pytpm/issues/3#issuecomment-12133978


### PR DESCRIPTION
This PR removes the title "Viziphant" from the navigation bar in the sphinx documentation.


See also: https://github.com/NeuralEnsemble/elephant/pull/534

