### PR TITLE
Update to quantities >0.14.0

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 neo>=0.9.0
 elephant>=0.9.0
 numpy>=1.18.1
-quantities>=0.12.1
+quantities>=0.14.1
 matplotlib>=3.3.2
 seaborn>=0.9.0
 # six>=1.10.0


### PR DESCRIPTION
## Changes
With this PR the requirements have been updated to quantities> 0.14.0

## Background
In version 0.14.0 of quantities a bug occurred in the `rescale` functionality, see also Issue : https://github.com/python-quantities/python-quantities/issues/215