### PR TITLE
 Fix/remove python 3.7

### DIFF
--- a/.github/workflows/CI_actions.yml
+++ b/.github/workflows/CI_actions.yml
@@ -25,8 +25,8 @@ jobs:
         matrix:
           # OS [ubuntu-latest, macos-latest, windows-latest]
           os: [ubuntu-latest]
-          # relevant python versions for viziphant: [3.7, 3.8, 3.9, "3.10"]
-          python-version: [3.7, 3.8, 3.9]
+          # relevant python versions for viziphant: [3.7, 3.8, 3.9, "3.10", 3.11]
+          python-version: [3.8, 3.9, "3.10", 3.11]
 
         # do not cancel all in-progress jobs if any matrix job fails
         fail-fast: false

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -9,7 +9,6 @@ sphinx:
   configuration: doc/conf.py
 
 python:
-    version: "3.10"
     install:
         - requirements: requirements/requirements-docs.txt
         - method: pip

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -9,6 +9,7 @@ sphinx:
   configuration: doc/conf.py
 
 python:
+    version: 3.8
     install:
         - requirements: requirements/requirements-docs.txt
         - method: pip

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -9,7 +9,7 @@ sphinx:
   configuration: doc/conf.py
 
 python:
-    version: 3.7
+    version: "3.10"
     install:
         - requirements: requirements/requirements-docs.txt
         - method: pip

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 neo>=0.9.0
 elephant>=0.9.0
-numpy>=1.18.1
+numpy>=1.19.5
 quantities>=0.12.1
 matplotlib>=3.3.2
 seaborn>=0.9.0


### PR DESCRIPTION
In accordance with NEP 29 + 1 year support for Python 3.7 and numpy 1.18 is dropped. 
(https://numpy.org/neps/nep-0029-deprecation_policy.html)