### PR TITLE
Enhance security of actions

### DIFF
--- a/.github/workflows/CI_actions.yml
+++ b/.github/workflows/CI_actions.yml
@@ -40,7 +40,7 @@ jobs:
        - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # corresponds to v3.5.2
 
        - name: Set up Python ${{ matrix.python-version }}
-         uses: actions/setup-python@v4
+         uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b # corresponds to v4.6.0
          with:
             python-version: ${{ matrix.python-version }}
 
@@ -91,7 +91,7 @@ jobs:
        - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # corresponds to v3.5.2
 
        - name: Set up Python ${{ matrix.python-version }}
-         uses: actions/setup-python@v4
+         uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b # corresponds to v4.6.0
          with:
             python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/CI_actions.yml
+++ b/.github/workflows/CI_actions.yml
@@ -37,7 +37,7 @@ jobs:
          id: date
          run: echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
 
-       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # corresponds to v3.5.2
+       - uses: actions/checkout@v3
 
        - name: Set up Python ${{ matrix.python-version }}
          uses: actions/setup-python@v4
@@ -88,7 +88,7 @@ jobs:
          id: date
          run: echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
 
-       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # corresponds to v3.5.2
+       - uses: actions/checkout@v3
 
        - name: Set up Python ${{ matrix.python-version }}
          uses: actions/setup-python@v4

--- a/.github/workflows/CI_actions.yml
+++ b/.github/workflows/CI_actions.yml
@@ -45,7 +45,7 @@ jobs:
             python-version: ${{ matrix.python-version }}
 
        - name: Cache pip
-         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # corresponds to V3.3.1
+         uses: actions/cache@v3
          with:
             path: ~/.cache/pip
             # Look to see if there is a cache hit for the corresponding requirements files
@@ -96,7 +96,7 @@ jobs:
             python-version: ${{ matrix.python-version }}
 
        - name: Cache pip
-         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # corresponds to V3.3.1
+         uses: actions/cache@v3
          with:
             path: ~/.cache/pip
             # Look to see if there is a cache hit for the corresponding requirements files

--- a/.github/workflows/CI_actions.yml
+++ b/.github/workflows/CI_actions.yml
@@ -40,7 +40,7 @@ jobs:
        - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # corresponds to v3.5.2
 
        - name: Set up Python ${{ matrix.python-version }}
-         uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b # corresponds to v4.6.0
+         uses: actions/setup-python@v4
          with:
             python-version: ${{ matrix.python-version }}
 
@@ -91,7 +91,7 @@ jobs:
        - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # corresponds to v3.5.2
 
        - name: Set up Python ${{ matrix.python-version }}
-         uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b # corresponds to v4.6.0
+         uses: actions/setup-python@v4
          with:
             python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/CI_actions.yml
+++ b/.github/workflows/CI_actions.yml
@@ -45,7 +45,7 @@ jobs:
             python-version: ${{ matrix.python-version }}
 
        - name: Cache pip
-         uses: actions/cache@v3
+         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # corresponds to V3.3.1
          with:
             path: ~/.cache/pip
             # Look to see if there is a cache hit for the corresponding requirements files
@@ -96,7 +96,7 @@ jobs:
             python-version: ${{ matrix.python-version }}
 
        - name: Cache pip
-         uses: actions/cache@v3
+         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # corresponds to V3.3.1
          with:
             path: ~/.cache/pip
             # Look to see if there is a cache hit for the corresponding requirements files

--- a/.github/workflows/CI_actions.yml
+++ b/.github/workflows/CI_actions.yml
@@ -37,7 +37,7 @@ jobs:
          id: date
          run: echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
 
-       - uses: actions/checkout@v3
+       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # corresponds to v3.5.2
 
        - name: Set up Python ${{ matrix.python-version }}
          uses: actions/setup-python@v4
@@ -88,7 +88,7 @@ jobs:
          id: date
          run: echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
 
-       - uses: actions/checkout@v3
+       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # corresponds to v3.5.2
 
        - name: Set up Python ${{ matrix.python-version }}
          uses: actions/setup-python@v4

--- a/.github/workflows/ebrains.yml
+++ b/.github/workflows/ebrains.yml
@@ -14,7 +14,7 @@ jobs:
       # this task will push the master branch of the source_repo (github) to the
       # destination_repo (ebrains gitlab)
       - name: syncmaster
-        uses:  wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83
+        uses: wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83
         # component owners need to set their own variables
         # the destination_repo format is
         # https://gitlab_service_account_name:${{ secrets.EBRAINS_GITLAB_ACCESS_TOKEN }}@gitlab.ebrains.eu/name_of_mirror.git
@@ -25,7 +25,7 @@ jobs:
           destination_branch: "master"
       # this task will push all tags from the source_repo to the destination_repo
       - name: synctags
-        uses:  wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83
+        uses: wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83
         with:
           source_repo: "INM-6/viziphant"
           source_branch: "refs/tags/*"

--- a/.github/workflows/ebrains.yml
+++ b/.github/workflows/ebrains.yml
@@ -14,7 +14,7 @@ jobs:
       # this task will push the master branch of the source_repo (github) to the
       # destination_repo (ebrains gitlab)
       - name: syncmaster
-        uses: wei/git-sync@v3
+        uses:  wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83
         # component owners need to set their own variables
         # the destination_repo format is
         # https://gitlab_service_account_name:${{ secrets.EBRAINS_GITLAB_ACCESS_TOKEN }}@gitlab.ebrains.eu/name_of_mirror.git
@@ -25,7 +25,7 @@ jobs:
           destination_branch: "master"
       # this task will push all tags from the source_repo to the destination_repo
       - name: synctags
-        uses: wei/git-sync@v3
+        uses:  wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83
         with:
           source_repo: "INM-6/viziphant"
           source_branch: "refs/tags/*"

--- a/.github/workflows/ebrains.yml
+++ b/.github/workflows/ebrains.yml
@@ -14,7 +14,7 @@ jobs:
       # this task will push the master branch of the source_repo (github) to the
       # destination_repo (ebrains gitlab)
       - name: syncmaster
-        uses: wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83
+        uses: wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83 # corresponds to v3
         # component owners need to set their own variables
         # the destination_repo format is
         # https://gitlab_service_account_name:${{ secrets.EBRAINS_GITLAB_ACCESS_TOKEN }}@gitlab.ebrains.eu/name_of_mirror.git
@@ -25,7 +25,7 @@ jobs:
           destination_branch: "master"
       # this task will push all tags from the source_repo to the destination_repo
       - name: synctags
-        uses: wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83
+        uses: wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83 # corresponds to v3
         with:
           source_repo: "INM-6/viziphant"
           source_branch: "refs/tags/*"


### PR DESCRIPTION
## Description
This pull request changes the way the third party GitHub Actions e.g. wei/git-sync are used. The corresponding PR on elephant is [#565](https://github.com/NeuralEnsemble/elephant/pull/565)
## Issue
Currently, version tags like "v3" in actions such as wei/git-sync@v3  could be changed at any time. 
## Fix
In order to prevent unwanted changes of the action used, specifying the explicit commit hash, such as wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83, significantly reduces the likelihood of unwanted changes.

This PR implements specific commit hashes for the GitHub actions currently in use.