### PR TITLE
[Doc] readthedocs: configuration key build.image is deprecated, changed to build.os

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,14 +2,14 @@
 version: 2
 
 build:
-    image: latest
+    os: ubuntu-22.04
 
 sphinx:
   builder: html
   configuration: doc/conf.py
 
 python:
-    version: 3.8
+    version: 3.11
     install:
         - requirements: requirements/requirements-docs.txt
         - method: pip

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,13 +4,12 @@ version: 2
 build:
     os: ubuntu-22.04
     tools:
-      python: "mambaforge-22.9"
+      python: "3.11"
 sphinx:
   builder: html
   configuration: doc/conf.py
 
 python:
-    version: 3.11
     install:
         - requirements: requirements/requirements-docs.txt
         - method: pip

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,8 @@ version: 2
 
 build:
     os: ubuntu-22.04
-
+tools:
+    python: "mambaforge-22.9"
 sphinx:
   builder: html
   configuration: doc/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,8 +3,8 @@ version: 2
 
 build:
     os: ubuntu-22.04
-tools:
-    python: "mambaforge-22.9"
+    tools:
+      python: "mambaforge-22.9"
 sphinx:
   builder: html
   configuration: doc/conf.py


### PR DESCRIPTION
This PR will fix the failing documentation build on readthedocs, due to latest changes.

The `readthedocs.yml` specifies the build configuration for the docs build on readthedocs. 

The configuration key `build.image` is deprecated, and replaced by `build.os`.

Moreover the Python version is now specified under the tools key.

```
Error

The configuration key "build.image" is deprecated. Use "build.os" instead to continue building your project. Read more at https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os
```