### PR TITLE
[Fix] remove .join in plot_ue function

### DIFF
--- a/viziphant/unitary_event_analysis.py
+++ b/viziphant/unitary_event_analysis.py
@@ -228,7 +228,8 @@ def plot_ue(spiketrains, Js_dict, significance_level=0.05,
 
     fig, axes = plt.subplots(nrows=6, sharex=True,
                              figsize=plot_params['figsize'])
-    axes[5].get_shared_y_axes().join(axes[0], axes[2], axes[5])
+    axes[5].sharey(axes[0])
+    axes[0].sharey(axes[2])
 
     for ax in (axes[0], axes[2], axes[5]):
         for n in range(n_neurons):


### PR DESCRIPTION
Wit release of matplotlib 3.8.0 the join method for sharing axis was removed.

This PR fixes the shared y-axes in the `plot_ue` function, by following the recommendation to use `Axes.sharey()` instead.

This change was also implemented in the corresponding UE tutorial in Elephant, see: https://github.com/NeuralEnsemble/elephant/pull/596

See: https://matplotlib.org/3.8.0/api/prev_api_changes/api_changes_3.8.0.html#removals
_Modifications to the Groupers returned by get_shared_x_axes and get_shared_y_axes are no longer allowed. Note that previously, calling e.g. join() would already fail to set up the correct structures for sharing axes; use [Axes.sharex](https://matplotlib.org/3.8.0/api/_as_gen/matplotlib.axes.Axes.sharex.html#matplotlib.axes.Axes.sharex) or [Axes.sharey](https://matplotlib.org/3.8.0/api/_as_gen/matplotlib.axes.Axes.sharey.html#matplotlib.axes.Axes.sharey) instead._