### PR TITLE
Hypergraph refactor

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,6 +4,5 @@ numpy>=1.19.5
 quantities>=0.14.1
 matplotlib>=3.3.2
 seaborn>=0.9.0
-bokeh>=3.0.0
 holoviews>=1.16.0
 networkx>=3.0.0

--- a/viziphant/patterns.py
+++ b/viziphant/patterns.py
@@ -463,7 +463,6 @@ def plot_patterns_hypergraph(patterns, num_neurons=None):
         patterns = cell_assembly_detection(bst, max_lag=2)
 
         viziphant.patterns.plot_patterns_hypergraph(patterns)
-        plt.show()
 
     """
     # If only patterns of a single dataset are given, wrap them in a list to

--- a/viziphant/patterns.py
+++ b/viziphant/patterns.py
@@ -527,7 +527,7 @@ def plot_patterns_hypergraph(patterns, pattern_size=None, num_neurons=None,\
     hypergraphs.append(hg)
     view = View(hypergraphs=hypergraphs, node_size=node_size, 
                 node_color=node_color, node_linewidth=node_linewidth)
-    fig = view.show(subset_style=VisualizationStyle.COLOR,
-                    triangulation_style=VisualizationStyle.INVISIBLE)
+    fig = view.show(subset_style=VisualizationStyle.styles['color'],
+                    triangulation_style=VisualizationStyle.styles['invisible'])
 
     return fig

--- a/viziphant/patterns.py
+++ b/viziphant/patterns.py
@@ -399,6 +399,7 @@ def plot_patterns(spiketrains, patterns, circle_sizes=(3, 50, 70),
     axes.yaxis.set_label_coords(-0.01, 0.5)
     return axes
 
+# TODO: add a parameter node_size
 def plot_patterns_hypergraph(patterns, num_neurons=None):
     """
     Hypergraph visualization of spike patterns.
@@ -461,7 +462,7 @@ def plot_patterns_hypergraph(patterns, num_neurons=None):
         bst.rescale('ms')
         patterns = cell_assembly_detection(bst, max_lag=2)
 
-        fig = viziphant.patterns.plot_patterns_hypergraph(patterns)
+        viziphant.patterns.plot_patterns_hypergraph(patterns)
         plt.show()
 
     """

--- a/viziphant/patterns.py
+++ b/viziphant/patterns.py
@@ -400,7 +400,8 @@ def plot_patterns(spiketrains, patterns, circle_sizes=(3, 50, 70),
     return axes
 
 def plot_patterns_hypergraph(patterns, pattern_size=None, num_neurons=None,\
-                            must_involve_neuron=None, node_size=3, node_color='white', node_linewidth=1):
+                            must_involve_neuron=None, node_size=3, node_color='white',
+                            node_linewidth=1, show_ids=True):
     """
     Hypergraph visualization of spike patterns.
 
@@ -446,6 +447,10 @@ def plot_patterns_hypergraph(patterns, pattern_size=None, num_neurons=None,\
 
     node_linewidth (optional) : int
             change the line width of the nodes
+
+    show_ids (optional) : bool
+        If True, the id of each neuron is displayed next to its node.
+        Default: True
 
     Returns
     -------
@@ -526,7 +531,8 @@ def plot_patterns_hypergraph(patterns, pattern_size=None, num_neurons=None,\
                     repulse=repulsive)
     hypergraphs.append(hg)
     view = View(hypergraphs=hypergraphs, node_size=node_size, 
-                node_color=node_color, node_linewidth=node_linewidth)
+                node_color=node_color, node_linewidth=node_linewidth,
+                show_ids=show_ids)
     fig = view.show(subset_style=VisualizationStyle.styles['color'],
                     triangulation_style=VisualizationStyle.styles['invisible'])
 

--- a/viziphant/patterns_src/hypergraph.py
+++ b/viziphant/patterns_src/hypergraph.py
@@ -104,15 +104,23 @@ class Hypergraph:
         edges = []
         weights = []
         graph_vertices = list(self.vertices.copy())
+        if isinstance(self.vertices[0], int):
+            max_vertex = max(max(hyperedge) for hyperedge in self.hyperedges)
+        else:
+            max_vertex = 0
+        if isinstance(max_vertex, str):
+            max_vertex = 0
         for i, hyperedge in enumerate(self.hyperedges):
             # Pseudo-vertex corresponding to hyperedge
-            graph_vertices.append(-i - 1)
+            pseudo_vertex = max_vertex + i + 1
+            graph_vertices.append(pseudo_vertex)
+
             for j, vertex in enumerate(hyperedge):
                 # Every vertex of a hyperedge is adjacent to the pseudo-vertex
                 # corresponding to the hyperedge
-                edges.append([-i - 1, vertex])
-                # Weight is equal to the weight of the hyperedge (if
-                # applicable)
+                edges.append([pseudo_vertex, vertex])
+
+                # Weight is equal to the weight of the hyperedge (if applicable)
                 if self.weights:
                     weights.append(self.weights[i])
                 # Unique unordered combinations of vertices of this hyperedge

--- a/viziphant/patterns_src/view.py
+++ b/viziphant/patterns_src/view.py
@@ -34,8 +34,7 @@ class View:
     In summary, this class represents an interactive tool
     for the visualization of hypergraphs.
     """
-
-    def __init__(self, hypergraphs, node_size=3, mark_neuron=None, node_color='white', title=None):
+    def __init__(self, hypergraphs, node_size=3, node_color='white', node_linewidth=1, title=None):
         """
         Constructs a View object that handles the visualization
         of the given hypergraphs.
@@ -49,11 +48,11 @@ class View:
         node_size (optional) : int
             Size of the nodes in the Hypergraphs
         
-        mark_neuron (optional) : int
-            Neuron with given number will be highlighted
-        
         node_color (optional) : String
             change the color of the nodes
+
+        node_linewidth (optional) : int
+            change the line width of the nodes
         """
 
         # Hyperedge drawings
@@ -71,11 +70,11 @@ class View:
         # Color of the nodes
         self.node_color = node_color
 
+        # Width of the Node lines
+        self.node_linewidth = node_linewidth
+
         # Selected title of the figure
         self.title = title
-
-        # Marked node will be in a different color
-        self.mark_neuron = mark_neuron
 
         # If no data was provided, fill in dummy data
         if hypergraphs:
@@ -125,7 +124,7 @@ class View:
         # The hv.Graph visualization is used for displaying the data
         # hv.Graph displays the nodes (and optionally binary edges) of a graph
         dynamic_map = hv.DynamicMap(hv.Graph, streams=[pipe])
-        
+
         # Define options for visualization
         dynamic_map.opts(
             # Some space around the Graph in order to avoid nodes being on the
@@ -142,7 +141,7 @@ class View:
             # All in black
             cmap=['#ffffff', '#ffffff'] * 50,
             # Size of the nodes
-            node_size=self.node_size, node_color=self.node_color, show_legend=True))
+            node_size=self.node_size, node_color=self.node_color, node_linewidth=self.node_linewidth, show_legend=True))
         return dynamic_map, pipe
 
     def _setup_hyperedge_drawing(self):

--- a/viziphant/patterns_src/view.py
+++ b/viziphant/patterns_src/view.py
@@ -53,8 +53,8 @@ class View:
         # Which color of the color map to use next
         self.current_color = 1
 
-        # Size of the vertices
-        self.node_radius = 0.2
+        # Size of the vertices TODO: add as parameter
+        self.node_radius = .2
 
         # Selected title of the figure
         self.title = title
@@ -225,8 +225,8 @@ class View:
         plot = self.dynamic_map * self.dynamic_map_edges
         # Set size of the plot to a square to avoid distortions
         self.plot = plot.redim.range(x=(-1, 11), y=(-1, 11))
-
-        axes = hv.render(plot, backend="matplotlib").axes[0]
+        # TODO: how to get axes? currently figure
+        axes = hv.render(plot, backend="matplotlib")
         return axes
 
     def draw_hyperedges(self,

--- a/viziphant/patterns_src/view.py
+++ b/viziphant/patterns_src/view.py
@@ -19,9 +19,12 @@ hv.extension('matplotlib')
 
 
 class VisualizationStyle:
-    INVISIBLE = 1
-    NOCOLOR = 2
-    COLOR = 3
+    styles = {
+        'invisible': 1,
+        'nocolor': 2,
+        'color': 3
+    }
+
 
 
 class View:
@@ -219,8 +222,8 @@ class View:
         return dynamic_map, pipe
 
     def show(self,
-             subset_style=VisualizationStyle.COLOR,
-             triangulation_style=VisualizationStyle.INVISIBLE):
+             subset_style=VisualizationStyle.styles['color'],
+             triangulation_style=VisualizationStyle.styles['invisible']):
         """
         Set up the correct arrangement and combination of the
         DynamicMap objects.
@@ -246,8 +249,8 @@ class View:
         return fig
         
     def draw_hyperedges(self, highlight_neuron=None,
-                        subset_style=VisualizationStyle.COLOR,
-                        triangulation_style=VisualizationStyle.INVISIBLE):
+                        subset_style=VisualizationStyle.styles['color'],
+                        triangulation_style=VisualizationStyle.styles['invisible']):
         """
         Handler for drawing the hyperedges of the hypergraphs
         in the given style
@@ -256,14 +259,14 @@ class View:
         ----------
         subset_style: enum VisualizationStyle
             How to do the subset standard visualization of the hyperedges:
-            VisualizationStyle.INVISIBLE => not at all
-            VisualizationStyle.NOCOLOR => Only contours without color
-            VisualizationStyle.COLOR => Contours filled with color
+            VisualizationStyle.styles['invisible] => not at all
+            VisualizationStyle.styles['nocolor] => Only contours without color
+            VisualizationStyle.styles['color] => Contours filled with color
         triangulation_style: enum VisualizationStyle
             How to do the triangulation visualization of the hyperedges:
-            VisualizationStyle.INVISIBLE => not at all
-            VisualizationStyle.NOCOLOR => Only contours without color
-            VisualizationStyle.COLOR => Contours filled with color
+            VisualizationStyle.styles['invisible] => not at all
+            VisualizationStyle.styles['nocolor] => Only contours without color
+            VisualizationStyle.styles['color] => Contours filled with color
         """
 
         # Collect all polygons to pass them to the visualization together
@@ -280,11 +283,11 @@ class View:
                 # Options are: invisible, nocolor, color
                 # If invisible, the corresponding visualization does not need
                 # to be constructed
-                if subset_style != VisualizationStyle.INVISIBLE:
+                if subset_style != VisualizationStyle.styles['invisible']:
                     polygons_subset.append(create_subset(hyperedge,
                                                          self.positions,
                                                          self.node_radius))
-                if triangulation_style != VisualizationStyle.INVISIBLE:
+                if triangulation_style != VisualizationStyle.styles['invisible']:
                     polygons_triang.extend(
                         create_triangulation(hyperedge, self.positions))
 
@@ -310,10 +313,10 @@ class View:
                 # Call the postprocessing function, color added only if needed
                 polygons.extend(process_polygons(
                         polygons_subset,
-                        subset_style == VisualizationStyle.COLOR))
+                        subset_style == VisualizationStyle.styles['color']))
                 polygons.extend(process_polygons(
                         polygons_triang,
-                        triangulation_style == VisualizationStyle.COLOR))
+                        triangulation_style == VisualizationStyle.styles['color']))
 
         # Save as instance attribute so widgets can work with the polygons
         self.polygons = polygons

--- a/viziphant/patterns_src/view.py
+++ b/viziphant/patterns_src/view.py
@@ -11,6 +11,7 @@ import holoviews as hv
 from holoviews import opts
 from holoviews.streams import Pipe
 import numpy as np
+import matplotlib.pyplot as plt
 
 from viziphant.patterns_src.hypergraph import Hypergraph
 
@@ -230,7 +231,8 @@ class View:
         # Set size of the plot to a square to avoid distortions
         self.plot = plot.redim.range(x=(-1, 11), y=(-1, 11))
 
-        return hv.render(plot, backend="matplotlib")
+        axes = hv.render(plot, backend="matplotlib").axes[0]
+        return axes
 
     def draw_hyperedges(self,
                         subset_style=VisualizationStyle.COLOR,

--- a/viziphant/patterns_src/view.py
+++ b/viziphant/patterns_src/view.py
@@ -35,7 +35,7 @@ class View:
     for the visualization of hypergraphs.
     """
 
-    def __init__(self, hypergraphs, title=None):
+    def __init__(self, hypergraphs, node_size=3, mark_neuron=None, node_color='white', title=None):
         """
         Constructs a View object that handles the visualization
         of the given hypergraphs.
@@ -45,6 +45,15 @@ class View:
         hypergraphs: list of Hypergraph objects
             Hypergraphs to be visualized.
             Each hypergraph should contain data of one data set.
+
+        node_size (optional) : int
+            Size of the nodes in the Hypergraphs
+        
+        mark_neuron (optional) : int
+            Neuron with given number will be highlighted
+        
+        node_color (optional) : String
+            change the color of the nodes
         """
 
         # Hyperedge drawings
@@ -53,11 +62,20 @@ class View:
         # Which color of the color map to use next
         self.current_color = 1
 
-        # Size of the vertices TODO: add as parameter
+        # radius of the hyperedges
         self.node_radius = .2
+        
+        # Size of the nodes (vertices of hypergraph)
+        self.node_size = node_size
+
+        # Color of the nodes
+        self.node_color = node_color
 
         # Selected title of the figure
         self.title = title
+
+        # Marked node will be in a different color
+        self.mark_neuron = mark_neuron
 
         # If no data was provided, fill in dummy data
         if hypergraphs:
@@ -107,7 +125,7 @@ class View:
         # The hv.Graph visualization is used for displaying the data
         # hv.Graph displays the nodes (and optionally binary edges) of a graph
         dynamic_map = hv.DynamicMap(hv.Graph, streams=[pipe])
-
+        
         # Define options for visualization
         dynamic_map.opts(
             # Some space around the Graph in order to avoid nodes being on the
@@ -124,8 +142,7 @@ class View:
             # All in black
             cmap=['#ffffff', '#ffffff'] * 50,
             # Size of the nodes
-            node_size=self.node_radius))
-
+            node_size=self.node_size, node_color=self.node_color, show_legend=True))
         return dynamic_map, pipe
 
     def _setup_hyperedge_drawing(self):
@@ -226,10 +243,10 @@ class View:
         # Set size of the plot to a square to avoid distortions
         self.plot = plot.redim.range(x=(-1, 11), y=(-1, 11))
         # TODO: how to get axes? currently figure
-        axes = hv.render(plot, backend="matplotlib")
-        return axes
-
-    def draw_hyperedges(self,
+        fig = hv.render(plot, backend="matplotlib")
+        return fig
+        
+    def draw_hyperedges(self, highlight_neuron=None,
                         subset_style=VisualizationStyle.COLOR,
                         triangulation_style=VisualizationStyle.INVISIBLE):
         """
@@ -396,7 +413,7 @@ class View:
         nodes = hv.Nodes((pos_x, pos_y, vertex_ids, vertex_labels),
                          extents=(0.01, 0.01, 0.01, 0.01),
                          vdims='Label')
-
+        
         new_data = ((edge_source, edge_target), nodes)
         self.pipe.send(new_data)
 

--- a/viziphant/patterns_src/view.py
+++ b/viziphant/patterns_src/view.py
@@ -173,11 +173,6 @@ class View:
             # differently
             import colorcet
             cmap = colorcet.glasbey[:len(self.hypergraphs[0].hyperedges)]
-        elif self.n_hypergraphs <= 10:
-            # Select Category10 colormap as default for up to 10 data sets
-            # This is an often used colormap
-            from bokeh.palettes import all_palettes
-            cmap = list(all_palettes['Category10'][10][1:self.n_hypergraphs+1])[::-1]
         else:
             # For larger numbers of data sets, select Glasbey colormap
             import colorcet

--- a/viziphant/patterns_src/view.py
+++ b/viziphant/patterns_src/view.py
@@ -42,7 +42,8 @@ class View:
     node_data = []
     polygons_data = []
 
-    def __init__(self, hypergraphs, node_size=5, node_color='white', node_linewidth=1, title=None):
+    def __init__(self, hypergraphs, node_size=5, node_color='white', node_linewidth=1,
+                title=None, show_ids=True):
         """
         Constructs a View object that handles the visualization
         of the given hypergraphs.
@@ -55,12 +56,16 @@ class View:
 
         node_size (optional) : int
             Size of the nodes in the Hypergraphs
-        
+
         node_color (optional) : String
             change the color of the nodes
 
         node_linewidth (optional) : int
             change the line width of the nodes
+
+        show_ids (optional) : bool
+            If True, the id of each vertex is displayed next to its node.
+            Default: True
         """
 
         # Hyperedge drawings
@@ -80,6 +85,9 @@ class View:
 
         # Width of the Node lines
         self.node_linewidth = node_linewidth
+
+        # Whether to display the id of each vertex next to its node
+        self.show_ids = show_ids
 
         # Selected title of the figure
         self.title = title
@@ -142,6 +150,17 @@ class View:
         # Visualization as an overlay of the graph visualization and the
         # hyperedge drawings
         plot = graph * poly
+
+        if self.show_ids:
+            # Display the id of each vertex next to its node
+            label_offset = .25
+            labels = hv.Labels((self.positions[:, 0] + label_offset,
+                               self.positions[:, 1] + label_offset,
+                               [str(vertex) for vertex in self.vertices]))
+            labels.opts(size=self.node_size, horizontalalignment='center',
+                       verticalalignment='center', color='black')
+            plot = plot * labels
+
         # Set size of the plot to a square to avoid distortions
         self.plot = plot.redim.range(x=(-1, 11), y=(-1, 11))
         # TODO: how to get axes? currently figure

--- a/viziphant/test/test_hypergraph.py
+++ b/viziphant/test/test_hypergraph.py
@@ -1,0 +1,358 @@
+"""
+Unit tests for the Hypergraph class.
+"""
+
+import unittest
+import numpy as np
+
+# import quantities as pq
+from numpy.testing import assert_array_equal
+from viziphant.patterns_src.hypergraph import Hypergraph
+import networkx as nx
+
+
+class HypergraphTestCase(unittest.TestCase):
+    """
+    This test is constructed to test the Creation and Transformation of the Hypergraph Class.
+    In the Setup function different Hypergraphs are created and being tested on different
+    Graph Transformation algorithms.
+    """
+
+    def setUp(self):
+        self.hypergraphs = []
+        # self.spiketrains = elephant.spike_train_generation.compound_poisson_process(
+        #    rate=5 * pq.Hz,
+        #    amplitude_distribution=[0] + [0.98] + [0] * 8 + [0.02],
+        #    t_stop=10 * pq.s,
+        # )
+        # self.patterns = elephant.spade.spade(
+        #    spiketrains=self.spiketrains,
+        #    binsize=1 * pq.ms,
+        #    winlen=1,
+        #    min_spikes=2,
+        #    n_surr=100,
+        #    dither=5 * pq.ms,
+        #    psr_param=[0, 0, 0],
+        #    output_format="patterns",
+        # )["patterns"]
+
+        # Hypergraph with characters as vertices
+        self.hyperedges = [["a", "b"], ["b", "c"], ["c", "d"]]
+        self.vertices = ["a", "b", "c", "d"]
+        self.vertex_labels = ["A", "B", "C", "D"]
+        self.weights = [1, 2, 3]
+        self.positions = np.array([[0, 0], [1, 1], [2, 2], [3, 3]])
+        self.repulse = True
+
+        self.hypergraphs.append(
+            Hypergraph(
+                self.hyperedges,
+                self.vertices,
+                self.vertex_labels,
+                self.weights,
+                self.positions,
+                self.repulse,
+            )
+        )
+
+        # normal Hypergraph
+        self.hyperedges = [[1, 2], [2, 3], [3, 4, 9], [5, 6, 7, 8]]
+        self.vertices = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        self.vertex_labels = [
+            "neuron1",
+            "neuron2",
+            "neuron3",
+            "neuron4",
+            "neuron5",
+            "neuron6",
+            "neuron7",
+            "neuron8",
+            "neuron9",
+        ]
+        self.weights = [1, 2, 1, 1]
+        self.positions = np.array(
+            [
+                [0, 0],
+                [1, 1],
+                [2, 2],
+                [3, 3],
+                [4, 4],
+                [5, 5],
+                [6, 6],
+                [7, 7],
+                [8, 8],
+                [9, 9],
+            ]
+        )
+        self.repulse = True
+
+        self.hypergraphs.append(
+            Hypergraph(
+                self.hyperedges,
+                self.vertices,
+                self.vertex_labels,
+                self.weights,
+                self.positions,
+                self.repulse,
+            )
+        )
+
+        # Hypergraph with negative Vertices
+        self.hyperedges = [[-1, -2], [-2, 3], [3, 4]]
+        self.vertices = [-1, -2, 3, 4]
+        self.vertex_labels = ["neuron1", "neuron2", "neuron3", "neuron4"]
+        self.weights = [3, 4, 5]
+        self.positions = np.array([[0, 0], [1, 1], [2, 2], [3, 3]])
+        self.repulse = False
+
+        self.hypergraphs.append(
+            Hypergraph(
+                self.hyperedges,
+                self.vertices,
+                self.vertex_labels,
+                self.weights,
+                self.positions,
+                self.repulse,
+            )
+        )
+
+        # Hypergraph without weights and labels
+        self.hyperedges = [["a", "b"], ["b", "c"], ["c", "d"]]
+        self.vertices = ["a", "b", "c", "d"]
+        self.vertex_labels = ["","","",""]
+        self.weights = []
+        self.positions = np.array([[0, 0], [1, 1], [2, 2], [3, 3]])
+        self.repulse = False
+
+        self.hypergraphs.append(
+            Hypergraph(
+                self.hyperedges,
+                self.vertices,
+                self.vertex_labels,
+                self.weights,
+                self.positions,
+                self.repulse,
+            )
+        )
+
+    def test_hypergraph_init(self):
+        hyperedges = [["a", "b"], ["b", "c"], ["c", "d"]]
+        vertices = ["a", "b", "c", "d"]
+        vertex_labels = ["A", "B", "C", "D"]
+        weights = [1, 2, 3]
+        positions = np.array([[0, 0], [1, 1], [2, 2], [3, 3]])
+        repulse = True
+
+        hypergraph = Hypergraph(
+            hyperedges, vertices, vertex_labels, weights, positions, repulse,
+        )
+        # check the Types
+        self.assertTrue(hypergraph.hyperedges == hyperedges)
+        self.assertTrue(hypergraph.vertices == vertices)
+        self.assertTrue(hypergraph.vertex_labels == vertex_labels)
+        self.assertTrue(hypergraph.weights == weights)
+        self.assertTrue(np.array_equal(hypergraph.vertices, vertices))
+        self.assertTrue(hypergraph.repulse)
+        self.assertEqual(len(hypergraph.weights), len(hypergraph.hyperedges))
+
+    # Test of getter method
+    def test_get_union_of_vertices(self):
+        for hypergraph in self.hypergraphs:
+            new_vertices = hypergraph.get_union_of_vertices([hypergraph])[0]
+            new_vertex_labels = hypergraph.get_union_of_vertices([hypergraph])[1]
+            # check equality after creation
+            assert_array_equal(new_vertices, hypergraph.vertices)
+            assert_array_equal(new_vertex_labels, hypergraph.vertex_labels)
+
+    def test_layout_hypergraph_len(self):
+        # nx.fruchterman_reingold_layout algorithm applied
+        for hypergraph in self.hypergraphs:
+            # check if data is consistent
+            self.assertEqual(
+                len(hypergraph.layout_hypergraph()), len(hypergraph.vertices)
+            )
+
+    # Test complete and star associated graph layouting algorithm
+    def test_complete_and_star_associated_graph(self):
+        for hypergraph in self.hypergraphs:
+            graph = hypergraph.complete_and_star_associated_graph()
+            self.assertIsInstance(graph, nx.Graph)
+            for vertex in hypergraph.vertices:
+                self.assertIn(vertex, list(graph.nodes))
+
+            edges = []
+            for elem in list(graph.edges):
+                edges.extend(elem)
+
+            for edge in hypergraph.hyperedges:
+                for node in edge:
+                    self.assertIn(node, edges)
+
+            # every hyperedge needs a weight
+            self.assertEqual(len(hypergraph.hyperedges), len(hypergraph.weights))
+
+            # nodes in graph equal nodes + len(hyperedges) because of pseudo vertices
+            self.assertEqual(
+                len(graph.nodes), len(hypergraph.vertices) + len(hypergraph.hyperedges)
+            )
+            # self.assertEqual(len(graph.edges), 9)
+
+    # Test complete and associated graph layouting algorithm
+    def test_complete_associated_graph(self):
+        for hypergraph in self.hypergraphs:
+            graph = hypergraph.complete_associated_graph()
+            # algorithm returns nx.Graph
+            self.assertIsInstance(graph, nx.Graph)
+            for vertex in hypergraph.vertices:
+                self.assertIn(vertex, list(graph.nodes))
+
+            edges = []
+            for elem in list(graph.edges):
+                edges.extend(elem)
+
+            for edge in hypergraph.hyperedges:
+                for node in edge:
+                    self.assertIn(node, edges)
+
+            self.assertEqual(len(hypergraph.hyperedges), len(hypergraph.weights))
+            assert_array_equal(list(graph.nodes), hypergraph.vertices)
+
+    # Test complete and weight associated graph layouting algorithm
+    def test_complete_weighted_associated_graph(self):
+        for hypergraph in self.hypergraphs:
+            graph = hypergraph.complete_weighted_associated_graph()
+            self.assertIsInstance(graph, nx.Graph)
+            for vertex in hypergraph.vertices:
+                self.assertIn(vertex, list(graph.nodes))
+
+            edges = []
+            for elem in list(graph.edges):
+                edges.extend(elem)
+
+            for edge in hypergraph.hyperedges:
+                for node in edge:
+                    self.assertIn(node, edges)
+
+            self.assertEqual(len(hypergraph.hyperedges), len(hypergraph.weights))
+            assert_array_equal(list(graph.nodes), hypergraph.vertices)
+
+    def test_empty_hypergraph(self):
+        # Hypergraph without hyperedges
+        hyperedges = []
+        vertices = ["a", "b", "c", "d"]
+        vertex_labels = ["A", "B", "C", "D"]
+        weights = [1, 2, 3]
+        positions = np.array([[0, 0], [1, 1], [2, 2], [3, 3]])
+        repulse = True
+
+        hypergraph = Hypergraph(
+            hyperedges, vertices, vertex_labels, weights, positions, repulse,
+        )
+        graph = hypergraph.complete_and_star_associated_graph()
+        self.assertIsInstance(graph, nx.Graph)
+        self.assertEqual(len(graph.nodes), 4)
+        self.assertEqual(len(graph.edges), 0)
+
+    def test_single_hyperedge(self):
+        # one hyperedge
+        hyperedges = [[1, 3]]
+        vertices = [1, 2, 3, 4]
+        vertex_labels = ["A", "B", "C", "D"]
+        weights = [1, 1]
+        positions = np.array([[0, 0], [1, 1], [2, 2], [3, 3]])
+        repulse = True
+
+        hypergraph = Hypergraph(
+            hyperedges, vertices, vertex_labels, weights, positions, repulse,
+        )
+        graph = hypergraph.complete_and_star_associated_graph()
+        self.assertEqual(len(graph.nodes), len(hypergraph.vertices))
+        self.assertEqual(len(graph.edges), 3)
+
+    def test_multiple_hyperedges(self):
+        # multiple hyperedges
+        hyperedges = [[1, 3], [2, 3, 4]]
+        vertices = [1, 2, 3, 4]
+        vertex_labels = ["A", "B", "C", "D"]
+        weights = [1, 1]
+        positions = np.array([[0, 0], [1, 1], [2, 2], [3, 3]])
+        repulse = True
+
+        hypergraph = Hypergraph(
+            hyperedges, vertices, vertex_labels, weights, positions, repulse,
+        )
+        graph = hypergraph.complete_and_star_associated_graph()
+        self.assertEqual(len(graph.nodes), 6)
+
+    def test_distance_equal(self):
+        # distance of edges should be equal because of equal weights
+        hyperedges = [[1, 2], [2, 3], [1, 3]]
+        vertices = [1, 2, 3]
+        vertex_labels = [1, 2, 3]
+        weights = [1, 1, 1]
+        positions = np.array([[0, 0], [1, 1], [2, 2]])
+        repulse = True
+
+        hypergraph = Hypergraph(
+            hyperedges, vertices, vertex_labels, weights, positions, repulse,
+        )
+        graph = hypergraph.complete_and_star_associated_graph()
+        distance = []
+        distance.append(nx.dijkstra_path_length(graph, 1, 2))
+        distance.append(nx.dijkstra_path_length(graph, 2, 3))
+        distance.append(nx.dijkstra_path_length(graph, 1, 3))
+        self.assertEqual(distance, [distance[0]] * len(distance))
+
+    def test_lower_distance(self):
+        # distance of connected vertices should be less or equal to not connected vertices
+        hyperedges = [[1, 2, 3], [2, 3]]
+        vertices = [1, 2, 3, 4]
+        vertex_labels = [1, 2, 3, 4]
+        weights = [17]
+        positions = np.array([[0, 0], [1, 1], [2, 2]])
+        repulse = True
+
+        hypergraph = Hypergraph(
+            hyperedges, vertices, vertex_labels, weights, positions, repulse,
+        )
+
+        graph = hypergraph.complete_and_star_associated_graph()
+        self.assertLessEqual(
+            nx.dijkstra_path_length(graph, 1, 2), nx.dijkstra_path_length(graph, 1, 4)
+        )
+
+    # Two Hypergraphs with the same data should be equal
+    def test_consistency(self):
+        hyperedges = [[1, 2, 3], [2, 3]]
+        vertices = [1, 2, 3, 4]
+        vertex_labels = [1, 2, 3, 4]
+        weights = [17]
+        positions = np.array([[0, 0], [1, 1], [2, 2]])
+        repulse = True
+
+        hypergraph = Hypergraph(
+            hyperedges,
+            vertices,
+            vertex_labels,
+            weights,
+            positions,
+            repulse,
+        )
+
+        graph1 = hypergraph.complete_and_star_associated_graph()
+        graph2 = hypergraph.complete_and_star_associated_graph()
+
+        self.assertEqual(len(graph1.edges), len(graph2.edges))
+        self.assertEqual(len(graph1.nodes), len(graph2.nodes))
+        self.assertEqual(graph1.edges, graph2.edges)
+        self.assertEqual(graph1.nodes, graph2.nodes)
+        self.assertEqual(nx.dijkstra_path_length(graph1, 1, 2), nx.dijkstra_path_length(graph2, 1, 2))
+        self.assertEqual(nx.dijkstra_path_length(graph1, 2,3), nx.dijkstra_path_length(graph2, 2, 3))
+        self.assertTrue(isinstance(graph1, nx.Graph))
+        self.assertTrue(isinstance(graph2, nx.Graph))
+        for edge in graph1.edges:
+            self.assertEqual(graph1.edges[edge]['weight'], graph2.edges[edge]['weight'])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replaces holoviews DynamicMap-based hypergraph rendering with static matplotlib, dropping the bokeh dependency.
- Adds pattern_size, must_involve_neuron filters and node_size/node_color/node_linewidth/show_ids styling options to plot_patterns_hypergraph.
- Adds unit tests for Hypergraph.
- CI: doc build now fails on Sphinx warnings instead of swallowing them