### PR TITLE
[MAIN] add Python 3.12

### DIFF
--- a/.github/workflows/CI_actions.yml
+++ b/.github/workflows/CI_actions.yml
@@ -12,7 +12,7 @@ on:
 
   # run on pushes to master branch
   push:
-    #branches: [master]
+    branches: [master]
 
 # jobs define the steps that will be executed on the runner
 jobs:

--- a/.github/workflows/CI_actions.yml
+++ b/.github/workflows/CI_actions.yml
@@ -8,7 +8,7 @@ on:
   # run on pull requests to master branch
   pull_request:
     branches: [master]
-    types: [synchronize, opened, reopened, ready_for_review]
+    types: [synchronize, opened, reopened]
 
   # run on pushes to master branch
   push:

--- a/.github/workflows/CI_actions.yml
+++ b/.github/workflows/CI_actions.yml
@@ -55,6 +55,7 @@ jobs:
        - name: Install dependencies
          run: |
             python -m pip install --upgrade pip
+            pip install setuptools
             pip install -r requirements/requirements-docs.txt
             pip install -r requirements/requirements.txt
             pip install .
@@ -105,6 +106,7 @@ jobs:
        - name: Install dependencies
          run: |
             python -m pip install --upgrade pip
+            pip install setuptools
             pip install -r requirements/requirements-docs.txt
             pip install -r requirements/requirements-tests.txt
             pip install -r requirements/requirements.txt

--- a/.github/workflows/CI_actions.yml
+++ b/.github/workflows/CI_actions.yml
@@ -25,8 +25,8 @@ jobs:
         matrix:
           # OS [ubuntu-latest, macos-latest, windows-latest]
           os: [ubuntu-latest]
-          # relevant python versions for viziphant: [3.7, 3.8, 3.9, "3.10", 3.11]
-          python-version: [3.8, 3.9, "3.10", 3.11]
+          # relevant python versions for viziphant: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12]
+          python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
 
         # do not cancel all in-progress jobs if any matrix job fails
         fail-fast: false


### PR DESCRIPTION
This pull request introduces support for Python 3.12, which was  released as of October 2, 2023.

Python 3.12 release, see: <https://www.python.org/downloads/release/python-3120/>

# Changes
- add Python 3.12 to CI workflow. 